### PR TITLE
ci: Add GitHub action for style checkers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  code_style:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout capa
+      uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: pip install 'isort==5.*' black
+    - name: Lint with isort
+      run: isort --profile black --length-sort --line-width 120 -c .
+    - name: Lint with black
+      run: black -l 120 --check .
+

--- a/capa/features/extractors/viv/__init__.py
+++ b/capa/features/extractors/viv/__init__.py
@@ -2,12 +2,12 @@
 
 import types
 
-import viv_utils
-
 import file
 import insn
 import function
+import viv_utils
 import basicblock
+
 import capa.features.extractors
 import capa.features.extractors.viv.file
 import capa.features.extractors.viv.insn

--- a/capa/features/freeze.py
+++ b/capa/features/freeze.py
@@ -205,6 +205,7 @@ def load(buf):
 def main(argv=None):
     import sys
     import argparse
+
     import capa.main
 
     if argv is None:

--- a/capa/main.py
+++ b/capa/main.py
@@ -9,12 +9,12 @@ import sys
 import hashlib
 import logging
 import os.path
+import argparse
 import datetime
 import textwrap
 import collections
 
 import tqdm
-import argparse
 import colorama
 
 import capa.rules

--- a/capa/render/__init__.py
+++ b/capa/render/__init__.py
@@ -245,8 +245,8 @@ def render_verbose(meta, rules, capabilities):
 
 def render_default(meta, rules, capabilities):
     # break import loop
-    import capa.render.verbose
     import capa.render.default
+    import capa.render.verbose
 
     doc = convert_capabilities_to_result_document(meta, rules, capabilities)
     return capa.render.default.render_default(doc)

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -59,7 +59,7 @@ You'll find that the `capa.exe` (Windows) or `capa` (Linux) executables in your 
 
 We use the following tools to ensure consistent code style and formatting:
   - [black](https://github.com/psf/black) code formatter, with `-l 120`
-  - [isort](https://pypi.org/project/isort/) code formatter, with `--length-sort --line-width 120`
+  - [isort 5](https://pypi.org/project/isort/) code formatter, with `--profile black --length-sort --line-width 120`
   - [dos2unix](https://linux.die.net/man/1/dos2unix) for UNIX-style LF newlines
   - [capafmt](https://github.com/fireeye/capa/blob/master/scripts/capafmt.py) rule formatter
 

--- a/scripts/capafmt.py
+++ b/scripts/capafmt.py
@@ -10,7 +10,6 @@ Copyright (C) 2020 FireEye, Inc. All Rights Reserved.
 """
 import sys
 import logging
-
 import argparse
 
 import capa.rules

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -13,10 +13,9 @@ import string
 import hashlib
 import logging
 import os.path
+import argparse
 import itertools
 import posixpath
-
-import argparse
 
 import capa.main
 import capa.engine

--- a/scripts/migrate-rules.py
+++ b/scripts/migrate-rules.py
@@ -13,9 +13,8 @@ import csv
 import sys
 import logging
 import os.path
-import collections
-
 import argparse
+import collections
 
 import capa.rules
 

--- a/scripts/show-capabilities-by-function.py
+++ b/scripts/show-capabilities-by-function.py
@@ -45,9 +45,9 @@ Copyright (C) 2020 FireEye, Inc. All Rights Reserved.
 import os
 import sys
 import logging
+import argparse
 import collections
 
-import argparse
 import colorama
 
 import capa.main

--- a/scripts/show-features.py
+++ b/scripts/show-features.py
@@ -60,7 +60,6 @@ Copyright (C) 2020 FireEye, Inc. All Rights Reserved.
 """
 import sys
 import logging
-
 import argparse
 
 import capa.main

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -2,13 +2,14 @@
 
 import textwrap
 
+from fixtures import *
+
 import capa.main
 import capa.helpers
 import capa.features
 import capa.features.insn
 import capa.features.freeze
 import capa.features.extractors
-from fixtures import *
 
 EXTRACTOR = capa.features.extractors.NullFeatureExtractor(
     {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,12 +2,13 @@
 
 import textwrap
 
+from fixtures import *
+
 import capa.main
 import capa.rules
 import capa.engine
 import capa.features
 import capa.features.extractors.viv
-from fixtures import *
 from capa.engine import *
 
 

--- a/tests/test_viv_features.py
+++ b/tests/test_viv_features.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2020 FireEye, Inc. All Rights Reserved.
 
 import viv_utils
+from fixtures import *
 
 import capa.features
 import capa.features.file
@@ -10,7 +11,6 @@ import capa.features.extractors.viv.file
 import capa.features.extractors.viv.insn
 import capa.features.extractors.viv.function
 import capa.features.extractors.viv.basicblock
-from fixtures import *
 
 
 def extract_file_features(vw, path):


### PR DESCRIPTION
Run isort 5 and black for every pull request or push.

You can see this working in [Ana06/capa](https://github.com/Ana06/capa/pull/1)

![Screen Shot 2020-07-15 at 11 45 33](https://user-images.githubusercontent.com/16052290/87530554-c8857080-c690-11ea-8446-31fab30f7f85.png)


The idea is to add jobs to the same action for rule linter and tests and to show a badge in the README with the status of the workflow (the name of the badge is the same as the workflow - `CI`). See https://github.com/fireeye/capa/pull/151

Closes https://github.com/fireeye/capa/issues/75
Closes https://github.com/fireeye/capa/issues/76