### PR TITLE
Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![capa](.github/logo.png)
 
+[![Code style checkers status](https://github.com/fireeye/capa/workflows/CI/badge.svg)](https://github.com/fireeye/capa/actions?query=workflow%3A%22CI%22)
 [![Number of rules](https://img.shields.io/badge/rules-261-blue.svg)](https://github.com/fireeye/capa-rules)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE.txt)
 


### PR DESCRIPTION
Add a GitHub action status badge for `CI` to README. You can see it working in [Ana06/capa](https://github.com/Ana06/capa):

![Screen Shot 2020-07-15 at 11 52 05](https://user-images.githubusercontent.com/16052290/87531268-be17a680-c691-11ea-8c68-396e15769eee.png)


**DO NOT MERGE** until the project is open sourced and GitHub Actions are enabled (otherwise the image won't exist and the README will look ugly).

Related to https://github.com/fireeye/capa/pull/150