### PR TITLE
add sha1/sha256 to default renderer

### DIFF
--- a/capa/render/default.py
+++ b/capa/render/default.py
@@ -21,6 +21,8 @@ def width(s, character_count):
 def render_meta(doc, ostream):
     rows = [
         (width("md5", 22), width(doc["meta"]["sample"]["md5"], 82)),
+        (width("sha1", 22), width(doc["meta"]["sample"]["sha1"], 82)),
+        (width("sha256", 22), width(doc["meta"]["sample"]["sha256"], 82)),
         ("path", doc["meta"]["sample"]["path"]),
     ]
 


### PR DESCRIPTION
Having the sha1 & sha256 hashes by default would actually be pretty useful I think. This change would add those.