### PR TITLE
Fix rule linter and run it in the CI GitHub action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,3 +23,20 @@ jobs:
     - name: Lint with black
       run: black -l 120 --check .
 
+  rule_linter:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout capa with rules submodule
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    # We don't need vivisect, so we can install capa using Python3
+    - name: Install capa
+      run: pip install -e .
+    - name: Run rule linter
+      run: python scripts/lint.py rules/
+

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -136,10 +136,12 @@ class MissingExampleOffset(Lint):
 
     def check_rule(self, ctx, rule):
         if rule.meta.get("scope") in ("function", "basic block"):
-            for example in rule.meta.get("examples", []):
-                if example and ":" not in example:
-                    logger.debug("example: %s", example)
-                    return True
+            examples = rule.meta.get("examples")
+            if isinstance(examples, list):
+                for example in examples:
+                    if example and ":" not in example:
+                        logger.debug("example: %s", example)
+                        return True
 
 
 class ExampleFileDNE(Lint):


### PR DESCRIPTION
- Prevent the linter to raise an exception if `examples` is `None`, as it for example currently happens in: `capa-rules/nursery/hash-data-using-murmur2.yml`. We could also remove the `examples` tag in those cases, but the linter shouldn't break in any case.

- Add the rule linter to the CI GitHub action. A similar actions should be added to [capa-rules](https://github.com/fireeye/capa-rules) as well (WIP in https://github.com/fireeye/capa-rules/pull/39)