### PR TITLE
Add vivisect installation to setup & Add tests to GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,3 +40,20 @@ jobs:
     - name: Run rule linter
       run: python scripts/lint.py rules/
 
+  tests:
+    runs-on: ubuntu-latest
+    needs: [code_style, rule_linter]
+    steps:
+    - name: Checkout capa with submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up Python 2.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 2.7
+    - name: Install capa
+      run: pip install -e .[dev]
+    - name: Run tests
+      run: pytest tests/
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![capa](.github/logo.png)
 
-[![Code style checkers status](https://github.com/fireeye/capa/workflows/CI/badge.svg)](https://github.com/fireeye/capa/actions?query=workflow%3A%22CI%22)
+[![CI status](https://github.com/fireeye/capa/workflows/CI/badge.svg)](https://github.com/fireeye/capa/actions?query=workflow%3ACI+event%3Apush+branch%3Amaster)
 [![Number of rules](https://img.shields.io/badge/rules-262-blue.svg)](https://github.com/fireeye/capa-rules)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE.txt)
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -18,25 +18,17 @@ By default, on MacOS Catalina or greater, Gatekeeper will block execution of the
 To install capa as a Python library, you'll need to install a few dependencies, and then use `pip` to fetch the capa module.
 Note: this technique doesn't pull the default rule set, so you should check it out separately from [capa-rules](https://github.com/fireeye/capa-rules/) and pass the directory to the entrypoint using `-r`.
 
-### 1. Install requirements
-First, install the requirements.
-`$ pip install https://github.com/williballenthin/vivisect/zipball/master`
-
-### 2. Install capa module
+### 1. Install capa module
 Second, use `pip` to install the capa module to your local Python environment. This fetches the library code to your computer but does not keep editable source files around for you to hack on. If you'd like to edit the source files, see below.
 `$ pip install https://github.com/fireeye/capa/archive/master.zip`
 
-### 3. Use capa
+### 2. Use capa
 You can now import the `capa` module from a Python script or use the IDA Pro plugins from the `capa/ida` directory. For more information please see the [usage](usage.md) documentation.
 
 ## Method 3: Inspecting the capa source code
 If you'd like to review and modify the capa source code, you'll need to check it out from GitHub and install it locally. By following these instructions, you'll maintain a local directory of source code that you can modify and run easily. 
 
-### 1. Install requirements
-First, install the requirements.
-`$ pip install https://github.com/williballenthin/vivisect/zipball/master`
-
-### 2. Check out source code
+### 1. Check out source code
 Next, clone the capa git repository. We use submodules to separate code, rules, and test data. See below to get all data at once. To only get the source code and our provided rules (common), follow these steps:
 - clone repository
   - `$ git clone https://github.com/fireeye/capa.git /local/path/to/src` (HTTPS)
@@ -56,8 +48,8 @@ To get all data at once use the `--recurse-submodules` option:
 - `$ git clone --recurse-submodules https://github.com/fireeye/capa.git /local/path/to/src` (HTTPS)
 - `$ git clone --recurse-submodules git@github.com:fireeye/capa.git /local/path/to/src` (SSH)
 
-### 3. Install the local source code
-Finally, use `pip` to install the source code in "editable" mode. This means that Python will load the capa module from the local directory rather than copying it to `site-packages` or `dist-packages`. This is good because it is easy to modify files and see the effects reflected immediately. But, be careful not to remove this directory unless uninstalling capa.
+### 2. Install the local source code
+Use `pip` to install the source code in "editable" mode. This means that Python will load the capa module from the local directory rather than copying it to `site-packages` or `dist-packages`. This is good because it is easy to modify files and see the effects reflected immediately. But, be careful not to remove this directory unless uninstalling capa.
 
 `$ pip install -e /local/path/to/src`
 
@@ -75,7 +67,7 @@ To install these development dependencies, run:
 
 Note that some development dependencies (including the black code formatter) require Python 3.
 
-### 4. Setup hooks [optional]
+### 3. Setup hooks [optional]
 
 If you plan to contribute to capa, you may want to setup the hooks.
 Run `scripts/setup-hooks.sh` to set the following hooks up:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if sys.version_info >= (3, 0):
 else:
     # py2
     requirements.append("enum34")
-    requirements.append("vivisect")
+    requirements.append("vivisect @ https://github.com/williballenthin/vivisect/tarball/master#egg=vivisect")
     requirements.append("viv-utils")
     requirements.append("networkx==2.2")  # v2.2 is last version supported by Python 2.7
 


### PR DESCRIPTION
- Vivisect is not available on PyPI. Tell `pip` in `setup.py` where to find it so that it is not needed to do it as a separate step.
- Add the tests to the CI GitHub action. Only run the tests if code style and rule linter succeed, as tests take some time to run. A similar actions should be added to `capa-testfiles`. Tests fail in this PR because they are broken in master: https://github.com/fireeye/capa/issues/174
- Update CI badge in README