### PR TITLE
main: don't crash when the .viv cannot be saved

### DIFF
--- a/capa/main.py
+++ b/capa/main.py
@@ -232,6 +232,9 @@ def get_shellcode_vw(sample, arch="auto", should_save=True):
         vw = max(vw_cands, key=lambda vw: len(vw.getFunctions()))
     else:
         vw = viv_utils.getShellcodeWorkspace(sample_bytes, arch, base=SHELLCODE_BASE, should_save=should_save)
+
+    vw.setMeta("StorageName", "%s.viv" % sample)
+
     return vw
 
 


### PR DESCRIPTION
when the source directory is not writable, don't bail out - just use the .viv in memory. this means that re-running will not be able to reuse the analysis, but i think the simplicity of this is probably ok.

![image](https://user-images.githubusercontent.com/156560/88314572-5d601d80-ccd2-11ea-8f3b-a02ec0fc0dfa.png)


closes #168