### PR TITLE
support negative offset features (and add IDA tests)

### DIFF
--- a/capa/features/extractors/helpers.py
+++ b/capa/features/extractors/helpers.py
@@ -67,3 +67,18 @@ def generate_api_features(apiname, va):
 
 def all_zeros(bytez):
     return all(b == 0 for b in builtins.bytes(bytez))
+
+
+def twos_complement(val, bits):
+    """
+    compute the 2's complement of int value val
+
+    from: https://stackoverflow.com/a/9147327/87207
+    """
+    # if sign bit is set e.g., 8bit: 128-255
+    if (val & (1 << (bits - 1))) != 0:
+        # compute negative value
+        return val - (1 << bits)
+    else:
+        # return positive value as is
+        return val

--- a/capa/features/extractors/ida/insn.py
+++ b/capa/features/extractors/ida/insn.py
@@ -150,6 +150,9 @@ def extract_insn_offset_features(f, bb, insn):
             # Ignore:
             #   mov esi, dword_1005B148[esi]
             continue
+
+        op_off = capa.features.extractors.helpers.twos_complement(op_off, 32)
+
         yield Offset(op_off), insn.ea
 
 

--- a/capa/features/extractors/ida/insn.py
+++ b/capa/features/extractors/ida/insn.py
@@ -144,8 +144,6 @@ def extract_insn_offset_features(f, bb, insn):
             continue
         p_info = capa.features.extractors.ida.helpers.get_op_phrase_info(op)
         op_off = p_info.get("offset", 0)
-        if 0 == op_off:
-            continue
         if idaapi.is_mapped(op_off):
             # Ignore:
             #   mov esi, dword_1005B148[esi]

--- a/capa/features/extractors/ida/insn.py
+++ b/capa/features/extractors/ida/insn.py
@@ -149,6 +149,9 @@ def extract_insn_offset_features(f, bb, insn):
             #   mov esi, dword_1005B148[esi]
             continue
 
+        # I believe that IDA encodes all offsets as two's complement in a u32.
+        # a 64-bit displacement isn't a thing, see:
+        # https://stackoverflow.com/questions/31853189/x86-64-assembly-why-displacement-not-64-bits
         op_off = capa.features.extractors.helpers.twos_complement(op_off, 32)
 
         yield Offset(op_off), insn.ea

--- a/capa/features/extractors/viv/insn.py
+++ b/capa/features/extractors/viv/insn.py
@@ -265,6 +265,8 @@ def extract_insn_offset_features(f, bb, insn):
         if oper.reg == envi.archs.amd64.disasm.REG_RBP:
             continue
 
+        # viv already decodes offsets as signed
+
         yield Offset(oper.disp), insn.va
 
 

--- a/scripts/import-to-bn.py
+++ b/scripts/import-to-bn.py
@@ -47,7 +47,7 @@ def append_func_cmt(bv, va, cmt):
 def load_analysis(bv):
     shortname = os.path.splitext(os.path.basename(bv.file.filename))[0]
     dirname = os.path.dirname(bv.file.filename)
-    log_info(f'dirname: {dirname}\nshortname: {shortname}\n')
+    log_info(f"dirname: {dirname}\nshortname: {shortname}\n")
     if os.access(os.path.join(dirname, shortname + ".js"), os.R_OK):
         path = os.path.join(dirname, shortname + ".js")
     elif os.access(os.path.join(dirname, shortname + ".json"), os.R_OK):
@@ -67,8 +67,8 @@ def load_analysis(bv):
         return -1
 
     a = doc["meta"]["sample"]["md5"].lower()
-    md5=Transform['MD5']
-    rawhex=Transform['RawHex']
+    md5 = Transform["MD5"]
+    rawhex = Transform["RawHex"]
     b = rawhex.encode(md5.encode(bv.parent_view.read(bv.parent_view.start, bv.parent_view.end))).decode("utf-8")
     if not a == b:
         log_error("sample mismatch")

--- a/scripts/import-to-bn.py
+++ b/scripts/import-to-bn.py
@@ -1,4 +1,4 @@
-j"""
+"""
 Binary Ninja plugin that imports a capa report,
 produced via `capa --json /path/to/sample`,
 into the current database.

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -259,17 +259,17 @@ class FeatureStringTooShort(Lint):
         return False
 
 
-class FeatureNegativeNumberOrOffset(Lint):
+class FeatureNegativeNumber(Lint):
     name = "feature value is negative"
     recommendation = "specify the number's two's complement representation"
     recommendation_template = (
-        "capa treats all numbers as unsigned values; you may specify the number's two's complement "
+        "capa treats number features as unsigned values; you may specify the number's two's complement "
         'representation; will not match on "{:d}"'
     )
 
     def check_features(self, ctx, features):
         for feature in features:
-            if isinstance(feature, (capa.features.insn.Number, capa.features.insn.Offset)):
+            if isinstance(feature, (capa.features.insn.Number,)):
                 if feature.value < 0:
                     self.recommendation = self.recommendation_template.format(feature.value)
                     return True
@@ -327,7 +327,7 @@ def lint_meta(ctx, rule):
 
 FEATURE_LINTS = (
     FeatureStringTooShort(),
-    FeatureNegativeNumberOrOffset(),
+    FeatureNegativeNumber(),
 )
 
 

--- a/scripts/show-features.py
+++ b/scripts/show-features.py
@@ -132,7 +132,11 @@ def main(argv=None):
 
             for insn in extractor.get_instructions(f, bb):
                 for feature, va in extractor.extract_insn_features(f, bb, insn):
-                    print("insn: 0x%08x: %s" % (va, feature))
+                    try:
+                        print("insn: 0x%08x: %s" % (va, feature))
+                    except UnicodeEncodeError:
+                        # may be an issue while piping to less and encountering non-ascii characters
+                        continue
 
     return 0
 

--- a/tests/test_ida_features.py
+++ b/tests/test_ida_features.py
@@ -1,0 +1,258 @@
+# run this script from within IDA with ./tests/data/mimikatz.exe open
+import logging
+import traceback
+import collections
+
+import pytest
+
+import capa.features
+import capa.features.file
+import capa.features.insn
+import capa.features.basicblock
+
+
+logger = logging.getLogger("test_ida_features")
+
+
+def get_extractor():
+    # have to import import this inline so pytest doesn't bail outside of IDA
+    import capa.features.extractors.ida
+    return capa.features.extractors.ida.IdaFeatureExtractor()
+
+
+def extract_file_features():
+    extractor = get_extractor()
+    features = set([])
+    for feature, va in extractor.extract_file_features():
+        features.add(feature)
+    return features
+
+
+def extract_function_features(f):
+    extractor = get_extractor()
+    features = collections.defaultdict(set)
+    for bb in extractor.get_basic_blocks(f):
+        for insn in extractor.get_instructions(f, bb):
+            for feature, va in extractor.extract_insn_features(f, bb, insn):
+                features[feature].add(va)
+        for feature, va in extractor.extract_basic_block_features(f, bb):
+            features[feature].add(va)
+    for feature, va in extractor.extract_function_features(f):
+        features[feature].add(va)
+    return features
+
+
+def extract_basic_block_features(f, bb):
+    extractor = get_extractor()
+    features = collections.defaultdict(set)
+    for insn in extractor.get_instructions(f, bb):
+        for feature, va in extractor.extract_insn_features(f, bb, insn):
+            features[feature].add(va)
+    for feature, va in extractor.extract_basic_block_features(f, bb):
+        features[feature].add(va)
+    return features
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_api_features():
+    # have to import import this inline so pytest doesn't bail outside of IDA
+    import idaapi
+    f = idaapi.get_func(0x403BAC)
+    features = extract_function_features(f)
+    assert capa.features.insn.API("advapi32.CryptAcquireContextW") in features
+    assert capa.features.insn.API("advapi32.CryptAcquireContext") in features
+    assert capa.features.insn.API("advapi32.CryptGenKey") in features
+    assert capa.features.insn.API("advapi32.CryptImportKey") in features
+    assert capa.features.insn.API("advapi32.CryptDestroyKey") in features
+    assert capa.features.insn.API("CryptAcquireContextW") in features
+    assert capa.features.insn.API("CryptAcquireContext") in features
+    assert capa.features.insn.API("CryptGenKey") in features
+    assert capa.features.insn.API("CryptImportKey") in features
+    assert capa.features.insn.API("CryptDestroyKey") in features
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_string_features():
+    import idaapi
+    f = idaapi.get_func(0x40105D)
+    features = extract_function_features(f)
+    assert capa.features.String("SCardControl") in features
+    assert capa.features.String("SCardTransmit") in features
+    assert capa.features.String("ACR  > ") in features
+    # other strings not in this function
+    assert capa.features.String("bcrypt.dll") not in features
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_byte_features():
+    import idaapi
+    f = idaapi.get_func(0x40105D)
+    features = extract_function_features(f)
+    wanted = capa.features.Bytes("SCardControl".encode('utf-16le'))
+    # use `==` rather than `is` because the result is not `True` but a truthy value.
+    assert wanted.evaluate(features) == True
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_number_features():
+    import idaapi
+    f = idaapi.get_func(0x40105D)
+    features = extract_function_features(f)
+    assert capa.features.insn.Number(0xFF) in features
+    assert capa.features.insn.Number(0x3136B0) in features
+    # the following are stack adjustments
+    assert capa.features.insn.Number(0xC) not in features
+    assert capa.features.insn.Number(0x10) not in features
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_offset_features():
+    import idaapi
+    f = idaapi.get_func(0x40105D)
+    features = extract_function_features(f)
+    assert capa.features.insn.Offset(0x0) in features
+    assert capa.features.insn.Offset(0x4) in features
+    assert capa.features.insn.Offset(0xC) in features
+    # the following are stack references
+    assert capa.features.insn.Offset(0x8) not in features
+    assert capa.features.insn.Offset(0x10) not in features
+
+    # this function has the following negative offsets
+    # movzx   ecx, byte ptr [eax-1]
+    # movzx   eax, byte ptr [eax-2]
+    f = idaapi.get_func(0x4011FB)
+    features = extract_function_features(f)
+    assert capa.features.insn.Offset(-0x1) in features
+    assert capa.features.insn.Offset(-0x2) in features
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_nzxor_features():
+    import idaapi
+    f = idaapi.get_func(0x410DFC)
+    features = extract_function_features(f)
+    assert capa.features.Characteristic("nzxor") in features  # 0x0410F0B
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_mnemonic_features():
+    import idaapi
+    f = idaapi.get_func(0x40105D)
+    features = extract_function_features(f)
+    assert capa.features.insn.Mnemonic("push") in features
+    assert capa.features.insn.Mnemonic("movzx") in features
+    assert capa.features.insn.Mnemonic("xor") in features
+
+    assert capa.features.insn.Mnemonic("in") not in features
+    assert capa.features.insn.Mnemonic("out") not in features
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_file_section_name_features():
+    features = extract_file_features()
+    assert capa.features.file.Section(".idata") in features
+    assert capa.features.file.Section(".text") in features
+    assert capa.features.file.Section(".nope") not in features
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_tight_loop_features():
+    import idaapi
+    extractor = get_extractor()
+    f = idaapi.get_func(0x402EC4)
+    for bb in extractor.get_basic_blocks(f):
+        if bb.__int__() != 0x402F8E:
+            continue
+        features = extract_basic_block_features(f, bb)
+        assert capa.features.Characteristic("tight loop") in features
+        assert capa.features.basicblock.BasicBlock() in features
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_tight_loop_bb_features():
+    import idaapi
+    extractor = get_extractor()
+    f = idaapi.get_func(0x402EC4)
+    for bb in extractor.get_basic_blocks(f):
+        if bb.__int__() != 0x402F8E:
+            continue
+        features = extract_basic_block_features(f, bb)
+        assert capa.features.Characteristic("tight loop") in features
+        assert capa.features.basicblock.BasicBlock() in features
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_file_import_name_features():
+    features = extract_file_features()
+    assert capa.features.file.Import("advapi32.CryptSetHashParam") in features
+    assert capa.features.file.Import("CryptSetHashParam") in features
+    assert capa.features.file.Import("kernel32.IsWow64Process") in features
+    assert capa.features.file.Import("msvcrt.exit") in features
+    assert capa.features.file.Import("cabinet.#11") in features
+    assert capa.features.file.Import("#11") not in features
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_stackstring_features():
+    import idaapi
+    f = idaapi.get_func(0x4556E5)
+    features = extract_function_features(f)
+    assert capa.features.Characteristic("stack string") in features
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_switch_features():
+    import idaapi
+    f = idaapi.get_func(0x409411)
+    features = extract_function_features(f)
+    assert capa.features.Characteristic("switch") in features
+
+    f = idaapi.get_func(0x409393)
+    features = extract_function_features(f)
+    assert capa.features.Characteristic("switch") not in features
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_function_calls_to():
+    import idaapi
+    f = idaapi.get_func(0x4011FB)
+    features = extract_function_features(f)
+    assert capa.features.Characteristic("calls to") in features
+    assert len(features[capa.features.Characteristic("calls to")]) == 1
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_function_calls_from():
+    import idaapi
+    f = idaapi.get_func(0x4011FB)
+    features = extract_function_features(f)
+    assert capa.features.Characteristic("calls from") in features
+    assert len(features[capa.features.Characteristic("calls from")]) == 3
+
+
+@pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
+def test_basic_block_count():
+    import idaapi
+    f = idaapi.get_func(0x4011FB)
+    features = extract_function_features(f)
+    assert len(features[capa.features.basicblock.BasicBlock()]) == 15
+
+
+if __name__ == "__main__":
+    print("-" * 80)
+
+    # invoke all functions in this module that start with `parse_`
+    for name in dir(sys.modules[__name__]):
+        if not name.startswith('test_'):
+            continue
+
+        test = getattr(sys.modules[__name__], name)
+        logger.debug('invoking test: %s', name)
+        sys.stderr.flush()
+        try:
+            test()
+        except AssertionError as e:
+            print("FAIL %s" % (name))
+            traceback.print_exc()
+        else:
+            print("OK   %s" % (name))

--- a/tests/test_ida_features.py
+++ b/tests/test_ida_features.py
@@ -10,7 +10,6 @@ import capa.features.file
 import capa.features.insn
 import capa.features.basicblock
 
-
 logger = logging.getLogger("test_ida_features")
 
 

--- a/tests/test_ida_features.py
+++ b/tests/test_ida_features.py
@@ -273,7 +273,7 @@ def test_basic_block_count():
 if __name__ == "__main__":
     print("-" * 80)
 
-    # invoke all functions in this module that start with `parse_`
+    # invoke all functions in this module that start with `test_`
     for name in dir(sys.modules[__name__]):
         if not name.startswith("test_"):
             continue

--- a/tests/test_ida_features.py
+++ b/tests/test_ida_features.py
@@ -14,9 +14,23 @@ import capa.features.basicblock
 logger = logging.getLogger("test_ida_features")
 
 
+def check_input_file():
+    import idautils
+
+    wanted = "5f66b82558ca92e54e77f216ef4c066c"
+    # some versions of IDA return a truncated version of the MD5.
+    # https://github.com/idapython/bin/issues/11
+    found = idautils.GetInputFileMD5().rstrip(b"\x00").decode("ascii").lower()
+    if not wanted.startswith(found):
+        raise RuntimeError("please run the tests against `mimikatz.exe`")
+
+
 def get_extractor():
+    check_input_file()
+
     # have to import import this inline so pytest doesn't bail outside of IDA
     import capa.features.extractors.ida
+
     return capa.features.extractors.ida.IdaFeatureExtractor()
 
 
@@ -57,6 +71,7 @@ def extract_basic_block_features(f, bb):
 def test_api_features():
     # have to import import this inline so pytest doesn't bail outside of IDA
     import idaapi
+
     f = idaapi.get_func(0x403BAC)
     features = extract_function_features(f)
     assert capa.features.insn.API("advapi32.CryptAcquireContextW") in features
@@ -74,6 +89,7 @@ def test_api_features():
 @pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
 def test_string_features():
     import idaapi
+
     f = idaapi.get_func(0x40105D)
     features = extract_function_features(f)
     assert capa.features.String("SCardControl") in features
@@ -86,9 +102,10 @@ def test_string_features():
 @pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
 def test_byte_features():
     import idaapi
+
     f = idaapi.get_func(0x40105D)
     features = extract_function_features(f)
-    wanted = capa.features.Bytes("SCardControl".encode('utf-16le'))
+    wanted = capa.features.Bytes("SCardControl".encode("utf-16le"))
     # use `==` rather than `is` because the result is not `True` but a truthy value.
     assert wanted.evaluate(features) == True
 
@@ -96,6 +113,7 @@ def test_byte_features():
 @pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
 def test_number_features():
     import idaapi
+
     f = idaapi.get_func(0x40105D)
     features = extract_function_features(f)
     assert capa.features.insn.Number(0xFF) in features
@@ -108,6 +126,7 @@ def test_number_features():
 @pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
 def test_offset_features():
     import idaapi
+
     f = idaapi.get_func(0x40105D)
     features = extract_function_features(f)
     assert capa.features.insn.Offset(0x0) in features
@@ -129,6 +148,7 @@ def test_offset_features():
 @pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
 def test_nzxor_features():
     import idaapi
+
     f = idaapi.get_func(0x410DFC)
     features = extract_function_features(f)
     assert capa.features.Characteristic("nzxor") in features  # 0x0410F0B
@@ -137,6 +157,7 @@ def test_nzxor_features():
 @pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
 def test_mnemonic_features():
     import idaapi
+
     f = idaapi.get_func(0x40105D)
     features = extract_function_features(f)
     assert capa.features.insn.Mnemonic("push") in features
@@ -158,6 +179,7 @@ def test_file_section_name_features():
 @pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
 def test_tight_loop_features():
     import idaapi
+
     extractor = get_extractor()
     f = idaapi.get_func(0x402EC4)
     for bb in extractor.get_basic_blocks(f):
@@ -171,6 +193,7 @@ def test_tight_loop_features():
 @pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
 def test_tight_loop_bb_features():
     import idaapi
+
     extractor = get_extractor()
     f = idaapi.get_func(0x402EC4)
     for bb in extractor.get_basic_blocks(f):
@@ -195,6 +218,7 @@ def test_file_import_name_features():
 @pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
 def test_stackstring_features():
     import idaapi
+
     f = idaapi.get_func(0x4556E5)
     features = extract_function_features(f)
     assert capa.features.Characteristic("stack string") in features
@@ -203,6 +227,7 @@ def test_stackstring_features():
 @pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
 def test_switch_features():
     import idaapi
+
     f = idaapi.get_func(0x409411)
     features = extract_function_features(f)
     assert capa.features.Characteristic("switch") in features
@@ -215,15 +240,22 @@ def test_switch_features():
 @pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
 def test_function_calls_to():
     import idaapi
+
+    # this function is used in a function pointer
     f = idaapi.get_func(0x4011FB)
     features = extract_function_features(f)
-    assert capa.features.Characteristic("calls to") in features
+    assert capa.features.Characteristic("calls to") not in features
+
+    # __FindPESection is called once
+    f = idaapi.get_func(0x470360)
+    features = extract_function_features(f)
     assert len(features[capa.features.Characteristic("calls to")]) == 1
 
 
 @pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
 def test_function_calls_from():
     import idaapi
+
     f = idaapi.get_func(0x4011FB)
     features = extract_function_features(f)
     assert capa.features.Characteristic("calls from") in features
@@ -233,6 +265,7 @@ def test_function_calls_from():
 @pytest.mark.skip(reason="IDA Pro tests must be run within IDA")
 def test_basic_block_count():
     import idaapi
+
     f = idaapi.get_func(0x4011FB)
     features = extract_function_features(f)
     assert len(features[capa.features.basicblock.BasicBlock()]) == 15
@@ -243,11 +276,11 @@ if __name__ == "__main__":
 
     # invoke all functions in this module that start with `parse_`
     for name in dir(sys.modules[__name__]):
-        if not name.startswith('test_'):
+        if not name.startswith("test_"):
             continue
 
         test = getattr(sys.modules[__name__], name)
-        logger.debug('invoking test: %s', name)
+        logger.debug("invoking test: %s", name)
         sys.stderr.flush()
         try:
             test()

--- a/tests/test_viv_features.py
+++ b/tests/test_viv_features.py
@@ -117,6 +117,13 @@ def test_offset_features(mimikatz):
     assert capa.features.insn.Offset(0x8) not in features
     assert capa.features.insn.Offset(0x10) not in features
 
+    # this function has the following negative offsets
+    # movzx   ecx, byte ptr [eax-1]
+    # movzx   eax, byte ptr [eax-2]
+    features = extract_function_features(viv_utils.Function(mimikatz.vw, 0x4011FB))
+    assert capa.features.insn.Offset(-0x1) in features
+    assert capa.features.insn.Offset(-0x2) in features
+
 
 def test_nzxor_features(mimikatz):
     features = extract_function_features(viv_utils.Function(mimikatz.vw, 0x410DFC))


### PR DESCRIPTION
codifies our decision to support offset features with negative values #197 by relaxing the lint and updating the IDA extractor.

in order to demonstrate that the IDA changes work, i implemented tests for the IDA extractor. these will not run during CI, but we can invoke them manually during development. they should be run with the `mimikatz.exe_` database open.

closes #197 
closes #202