### PR TITLE
 Enable descriptions for statement nodes

### DIFF
--- a/capa/engine.py
+++ b/capa/engine.py
@@ -104,9 +104,9 @@ class Result(object):
 class And(Statement):
     """match if all of the children evaluate to True."""
 
-    def __init__(self, *children):
+    def __init__(self, children):
         super(And, self).__init__()
-        self.children = list(children)
+        self.children = children
 
     def evaluate(self, ctx):
         results = [child.evaluate(ctx) for child in self.children]
@@ -117,9 +117,9 @@ class And(Statement):
 class Or(Statement):
     """match if any of the children evaluate to True."""
 
-    def __init__(self, *children):
+    def __init__(self, children):
         super(Or, self).__init__()
-        self.children = list(children)
+        self.children = children
 
     def evaluate(self, ctx):
         results = [child.evaluate(ctx) for child in self.children]
@@ -143,7 +143,7 @@ class Not(Statement):
 class Some(Statement):
     """match if at least N of the children evaluate to True."""
 
-    def __init__(self, count, *children):
+    def __init__(self, count, children):
         super(Some, self).__init__()
         self.count = count
         self.children = list(children)

--- a/capa/engine.py
+++ b/capa/engine.py
@@ -20,12 +20,16 @@ class Statement(object):
      and to declare the interface method `evaluate`
     """
 
-    def __init__(self):
+    def __init__(self, description=None):
         super(Statement, self).__init__()
         self.name = self.__class__.__name__
+        self.description = description
 
     def __str__(self):
-        return "%s(%s)" % (self.name.lower(), ",".join(map(str, self.get_children())))
+        if self.description:
+            return "%s(%s = %s)" % (self.name.lower(), ",".join(map(str, self.get_children())), self.description)
+        else:
+            return "%s(%s)" % (self.name.lower(), ",".join(map(str, self.get_children())))
 
     def __repr__(self):
         return str(self)
@@ -104,8 +108,8 @@ class Result(object):
 class And(Statement):
     """match if all of the children evaluate to True."""
 
-    def __init__(self, children):
-        super(And, self).__init__()
+    def __init__(self, children, description=None):
+        super(And, self).__init__(description=description)
         self.children = children
 
     def evaluate(self, ctx):
@@ -117,8 +121,8 @@ class And(Statement):
 class Or(Statement):
     """match if any of the children evaluate to True."""
 
-    def __init__(self, children):
-        super(Or, self).__init__()
+    def __init__(self, children, description=None):
+        super(Or, self).__init__(description=description)
         self.children = children
 
     def evaluate(self, ctx):
@@ -130,8 +134,8 @@ class Or(Statement):
 class Not(Statement):
     """match only if the child evaluates to False."""
 
-    def __init__(self, child):
-        super(Not, self).__init__()
+    def __init__(self, child, description=None):
+        super(Not, self).__init__(description=description)
         self.child = child
 
     def evaluate(self, ctx):
@@ -143,10 +147,10 @@ class Not(Statement):
 class Some(Statement):
     """match if at least N of the children evaluate to True."""
 
-    def __init__(self, count, children):
-        super(Some, self).__init__()
+    def __init__(self, count, children, description=None):
+        super(Some, self).__init__(description=description)
         self.count = count
-        self.children = list(children)
+        self.children = children
 
     def evaluate(self, ctx):
         results = [child.evaluate(ctx) for child in self.children]
@@ -161,8 +165,8 @@ class Some(Statement):
 class Range(Statement):
     """match if the child is contained in the ctx set with a count in the given range."""
 
-    def __init__(self, child, min=None, max=None):
-        super(Range, self).__init__()
+    def __init__(self, child, min=None, max=None, description=None):
+        super(Range, self).__init__(description=description)
         self.child = child
         self.min = min if min is not None else 0
         self.max = max if max is not None else (1 << 64 - 1)

--- a/capa/render/__init__.py
+++ b/capa/render/__init__.py
@@ -26,39 +26,21 @@ def convert_statement_to_result_document(statement):
             "type": "range"
         },
     """
-    if isinstance(statement, capa.engine.And):
-        return {
-            "type": "and",
-        }
-    elif isinstance(statement, capa.engine.Or):
-        return {
-            "type": "or",
-        }
-    elif isinstance(statement, capa.engine.Not):
-        return {
-            "type": "not",
-        }
-    elif isinstance(statement, capa.engine.Some) and statement.count == 0:
-        return {"type": "optional"}
-    elif isinstance(statement, capa.engine.Some) and statement.count > 0:
-        return {
-            "type": "some",
-            "count": statement.count,
-        }
-    elif isinstance(statement, capa.engine.Range):
-        return {
-            "type": "range",
-            "min": statement.min,
-            "max": statement.max,
-            "child": convert_feature_to_result_document(statement.child),
-        }
-    elif isinstance(statement, capa.engine.Subscope):
-        return {
-            "type": "subscope",
-            "subscope": statement.scope,
-        }
-    else:
-        raise RuntimeError("unexpected match statement type: " + str(statement))
+    statement_type = statement.name.lower()
+    result = {"type": statement_type}
+
+    if statement_type == "some" and statement.count == 0:
+        result["type"] = "optional"
+    elif statement_type == "some":
+        result["count"] = statement.count
+    elif statement_type == "range":
+        result["min"] = statement.min
+        result["max"] = statement.max
+        result["child"] = convert_feature_to_result_document(statement.child)
+    elif statement_type == "subscope":
+        result["subscope"] = statement.scope
+
+    return result
 
 
 def convert_feature_to_result_document(feature):

--- a/capa/render/__init__.py
+++ b/capa/render/__init__.py
@@ -28,6 +28,8 @@ def convert_statement_to_result_document(statement):
     """
     statement_type = statement.name.lower()
     result = {"type": statement_type}
+    if statement.description:
+        result["description"] = statement.description
 
     if statement_type == "some" and statement.count == 0:
         result["type"] = "optional"

--- a/capa/render/vverbose.py
+++ b/capa/render/vverbose.py
@@ -36,15 +36,11 @@ def render_locations(ostream, match):
 
 def render_statement(ostream, match, statement, indent=0):
     ostream.write("  " * indent)
-    if statement["type"] in ("and", "or", "optional"):
+    if statement["type"] in ("and", "or", "optional", "not", "subscope"):
         ostream.write(statement["type"])
         ostream.writeln(":")
-    elif statement["type"] == "not":
-        # this statement is handled specially in `render_match` using the MODE_SUCCESS/MODE_FAILURE flags.
-        ostream.writeln("not:")
     elif statement["type"] == "some":
-        ostream.write("%d or more" % (statement["count"]))
-        ostream.writeln(":")
+        ostream.writeln("%d or more:" % (statement["count"]))
     elif statement["type"] == "range":
         # `range` is a weird node, its almost a hybrid of statement+feature.
         # it is a specific feature repeated multiple times.
@@ -72,10 +68,7 @@ def render_statement(ostream, match, statement, indent=0):
             ostream.write("between %d and %d" % (statement["min"], statement["max"]))
 
         render_locations(ostream, match)
-        ostream.write("\n")
-    elif statement["type"] == "subscope":
-        ostream.write(statement["subscope"])
-        ostream.writeln(":")
+        ostream.writeln("")
     else:
         raise RuntimeError("unexpected match statement type: " + str(statement))
 

--- a/capa/render/vverbose.py
+++ b/capa/render/vverbose.py
@@ -38,9 +38,15 @@ def render_statement(ostream, match, statement, indent=0):
     ostream.write("  " * indent)
     if statement["type"] in ("and", "or", "optional", "not", "subscope"):
         ostream.write(statement["type"])
-        ostream.writeln(":")
+        ostream.write(":")
+        if statement.get("description"):
+            ostream.write(" = %s" % statement["description"])
+        ostream.writeln("")
     elif statement["type"] == "some":
-        ostream.writeln("%d or more:" % (statement["count"]))
+        ostream.write("%d or more:" % (statement["count"]))
+        if statement.get("description"):
+            ostream.write(" = %s" % statement["description"])
+        ostream.writeln("")
     elif statement["type"] == "range":
         # `range` is a weird node, its almost a hybrid of statement+feature.
         # it is a specific feature repeated multiple times.
@@ -67,6 +73,8 @@ def render_statement(ostream, match, statement, indent=0):
         else:
             ostream.write("between %d and %d" % (statement["min"], statement["max"]))
 
+        if statement.get("description"):
+            ostream.write(" = %s" % statement["description"])
         render_locations(ostream, match)
         ostream.writeln("")
     else:

--- a/capa/rules.py
+++ b/capa/rules.py
@@ -265,21 +265,21 @@ def build_statements(d, scope):
 
     key = list(d.keys())[0]
     if key == "and":
-        return And([build_statements(dd, scope) for dd in d[key]])
+        return And([build_statements(dd, scope) for dd in d[key]], description=d.get("description"))
     elif key == "or":
-        return Or([build_statements(dd, scope) for dd in d[key]])
+        return Or([build_statements(dd, scope) for dd in d[key]], description=d.get("description"))
     elif key == "not":
         if len(d[key]) != 1:
             raise InvalidRule("not statement must have exactly one child statement")
-        return Not(build_statements(d[key][0], scope))
+        return Not(build_statements(d[key][0], scope), description=d.get("description"))
     elif key.endswith(" or more"):
         count = int(key[: -len("or more")])
-        return Some(count, [build_statements(dd, scope) for dd in d[key]])
+        return Some(count, [build_statements(dd, scope) for dd in d[key]], description=d.get("description"))
     elif key == "optional":
         # `optional` is an alias for `0 or more`
         # which is useful for documenting behaviors,
         # like with `write file`, we might say that `WriteFile` is optionally found alongside `CreateFileA`.
-        return Some(0, [build_statements(dd, scope) for dd in d[key]])
+        return Some(0, [build_statements(dd, scope) for dd in d[key]], description=d.get("description"))
 
     elif key == "function":
         if scope != FILE_SCOPE:
@@ -338,18 +338,18 @@ def build_statements(d, scope):
 
         count = d[key]
         if isinstance(count, int):
-            return Range(feature, min=count, max=count)
+            return Range(feature, min=count, max=count, description=d.get("description"))
         elif count.endswith(" or more"):
             min = parse_int(count[: -len(" or more")])
             max = None
-            return Range(feature, min=min, max=max)
+            return Range(feature, min=min, max=max, description=d.get("description"))
         elif count.endswith(" or fewer"):
             min = None
             max = parse_int(count[: -len(" or fewer")])
-            return Range(feature, min=min, max=max)
+            return Range(feature, min=min, max=max, description=d.get("description"))
         elif count.startswith("("):
             min, max = parse_range(count)
-            return Range(feature, min=min, max=max)
+            return Range(feature, min=min, max=max, description=d.get("description"))
         else:
             raise InvalidRule("unexpected range: %s" % (count))
     elif key == "string" and not isinstance(d[key], six.string_types):

--- a/capa/rules.py
+++ b/capa/rules.py
@@ -265,21 +265,21 @@ def build_statements(d, scope):
 
     key = list(d.keys())[0]
     if key == "and":
-        return And(*[build_statements(dd, scope) for dd in d[key]])
+        return And([build_statements(dd, scope) for dd in d[key]])
     elif key == "or":
-        return Or(*[build_statements(dd, scope) for dd in d[key]])
+        return Or([build_statements(dd, scope) for dd in d[key]])
     elif key == "not":
         if len(d[key]) != 1:
             raise InvalidRule("not statement must have exactly one child statement")
-        return Not(*[build_statements(dd, scope) for dd in d[key]])
+        return Not(build_statements(d[key][0], scope))
     elif key.endswith(" or more"):
         count = int(key[: -len("or more")])
-        return Some(count, *[build_statements(dd, scope) for dd in d[key]])
+        return Some(count, [build_statements(dd, scope) for dd in d[key]])
     elif key == "optional":
         # `optional` is an alias for `0 or more`
         # which is useful for documenting behaviors,
         # like with `write file`, we might say that `WriteFile` is optionally found alongside `CreateFileA`.
-        return Some(0, *[build_statements(dd, scope) for dd in d[key]])
+        return Some(0, [build_statements(dd, scope) for dd in d[key]])
 
     elif key == "function":
         if scope != FILE_SCOPE:
@@ -288,7 +288,7 @@ def build_statements(d, scope):
         if len(d[key]) != 1:
             raise InvalidRule("subscope must have exactly one child statement")
 
-        return Subscope(FUNCTION_SCOPE, *[build_statements(dd, FUNCTION_SCOPE) for dd in d[key]])
+        return Subscope(FUNCTION_SCOPE, build_statements(d[key][0], FUNCTION_SCOPE))
 
     elif key == "basic block":
         if scope != FUNCTION_SCOPE:
@@ -297,7 +297,7 @@ def build_statements(d, scope):
         if len(d[key]) != 1:
             raise InvalidRule("subscope must have exactly one child statement")
 
-        return Subscope(BASIC_BLOCK_SCOPE, *[build_statements(dd, BASIC_BLOCK_SCOPE) for dd in d[key]])
+        return Subscope(BASIC_BLOCK_SCOPE, build_statements(d[key][0], BASIC_BLOCK_SCOPE))
 
     elif key.startswith("count(") and key.endswith(")"):
         # e.g.:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -22,21 +22,21 @@ def test_number():
 
 
 def test_and():
-    assert And(Number(1)).evaluate({Number(0): {1}}) == False
-    assert And(Number(1)).evaluate({Number(1): {1}}) == True
-    assert And(Number(1), Number(2)).evaluate({Number(0): {1}}) == False
-    assert And(Number(1), Number(2)).evaluate({Number(1): {1}}) == False
-    assert And(Number(1), Number(2)).evaluate({Number(2): {1}}) == False
-    assert And(Number(1), Number(2)).evaluate({Number(1): {1}, Number(2): {2}}) == True
+    assert And([Number(1)]).evaluate({Number(0): {1}}) == False
+    assert And([Number(1)]).evaluate({Number(1): {1}}) == True
+    assert And([Number(1), Number(2)]).evaluate({Number(0): {1}}) == False
+    assert And([Number(1), Number(2)]).evaluate({Number(1): {1}}) == False
+    assert And([Number(1), Number(2)]).evaluate({Number(2): {1}}) == False
+    assert And([Number(1), Number(2)]).evaluate({Number(1): {1}, Number(2): {2}}) == True
 
 
 def test_or():
-    assert Or(Number(1)).evaluate({Number(0): {1}}) == False
-    assert Or(Number(1)).evaluate({Number(1): {1}}) == True
-    assert Or(Number(1), Number(2)).evaluate({Number(0): {1}}) == False
-    assert Or(Number(1), Number(2)).evaluate({Number(1): {1}}) == True
-    assert Or(Number(1), Number(2)).evaluate({Number(2): {1}}) == True
-    assert Or(Number(1), Number(2)).evaluate({Number(1): {1}, Number(2): {2}}) == True
+    assert Or([Number(1)]).evaluate({Number(0): {1}}) == False
+    assert Or([Number(1)]).evaluate({Number(1): {1}}) == True
+    assert Or([Number(1), Number(2)]).evaluate({Number(0): {1}}) == False
+    assert Or([Number(1), Number(2)]).evaluate({Number(1): {1}}) == True
+    assert Or([Number(1), Number(2)]).evaluate({Number(2): {1}}) == True
+    assert Or([Number(1), Number(2)]).evaluate({Number(1): {1}, Number(2): {2}}) == True
 
 
 def test_not():
@@ -45,20 +45,20 @@ def test_not():
 
 
 def test_some():
-    assert Some(0, Number(1)).evaluate({Number(0): {1}}) == True
-    assert Some(1, Number(1)).evaluate({Number(0): {1}}) == False
+    assert Some(0, [Number(1)]).evaluate({Number(0): {1}}) == True
+    assert Some(1, [Number(1)]).evaluate({Number(0): {1}}) == False
 
-    assert Some(2, Number(1), Number(2), Number(3)).evaluate({Number(0): {1}}) == False
-    assert Some(2, Number(1), Number(2), Number(3)).evaluate({Number(0): {1}, Number(1): {1}}) == False
-    assert Some(2, Number(1), Number(2), Number(3)).evaluate({Number(0): {1}, Number(1): {1}, Number(2): {1}}) == True
+    assert Some(2, [Number(1), Number(2), Number(3)]).evaluate({Number(0): {1}}) == False
+    assert Some(2, [Number(1), Number(2), Number(3)]).evaluate({Number(0): {1}, Number(1): {1}}) == False
+    assert Some(2, [Number(1), Number(2), Number(3)]).evaluate({Number(0): {1}, Number(1): {1}, Number(2): {1}}) == True
     assert (
-        Some(2, Number(1), Number(2), Number(3)).evaluate(
+        Some(2, [Number(1), Number(2), Number(3)]).evaluate(
             {Number(0): {1}, Number(1): {1}, Number(2): {1}, Number(3): {1}}
         )
         == True
     )
     assert (
-        Some(2, Number(1), Number(2), Number(3)).evaluate(
+        Some(2, [Number(1), Number(2), Number(3)]).evaluate(
             {Number(0): {1}, Number(1): {1}, Number(2): {1}, Number(3): {1}, Number(4): {1},}
         )
         == True
@@ -66,11 +66,11 @@ def test_some():
 
 
 def test_complex():
-    assert True == Or(And(Number(1), Number(2)), Or(Number(3), Some(2, Number(4), Number(5), Number(6))),).evaluate(
-        {Number(5): {1}, Number(6): {1}, Number(7): {1}, Number(8): {1}}
-    )
+    assert True == Or(
+        [And([Number(1), Number(2)]), Or([Number(3), Some(2, [Number(4), Number(5), Number(6)])])]
+    ).evaluate({Number(5): {1}, Number(6): {1}, Number(7): {1}, Number(8): {1}})
 
-    assert False == Or(And(Number(1), Number(2)), Or(Number(3), Some(2, Number(4), Number(5)))).evaluate(
+    assert False == Or([And([Number(1), Number(2)]), Or([Number(3), Some(2, [Number(4), Number(5)])])]).evaluate(
         {Number(5): {1}, Number(6): {1}, Number(7): {1}, Number(8): {1}}
     )
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -83,6 +83,16 @@ def test_rule_yaml_descriptions():
                     - string: '/SELECT.*FROM.*WHERE/i'
                       description: SQL WHERE Clause
                     - count(number(2 = AF_INET/SOCK_DGRAM)): 2
+                    - or:
+                        - and:
+                            - offset: 0x50 = IMAGE_NT_HEADERS.OptionalHeader.SizeOfImage
+                            - offset: 0x34 = IMAGE_NT_HEADERS.OptionalHeader.ImageBase
+                          description: 32-bits
+                        - and:
+                            - offset: 0x50 = IMAGE_NT_HEADERS64.OptionalHeader.SizeOfImage
+                            - offset: 0x30 = IMAGE_NT_HEADERS64.OptionalHeader.ImageBase
+                          description: 64-bits
+                      description: PE headers offsets
         """
     )
     r = capa.rules.Rule.from_yaml(rule)
@@ -93,6 +103,8 @@ def test_rule_yaml_descriptions():
                 Number(2): {2, 3},
                 String("This program cannot be run in DOS mode."): {4},
                 String("SELECT password FROM hidden_table WHERE user == admin"): {5},
+                Offset(0x50): {6},
+                Offset(0x30): {7},
             }
         )
         == True


### PR DESCRIPTION
Enable descriptions for statement nodes such as `and` and `or`. Includes some refactoring to facilitate the implementation.

Use of case in: fireeye/capa-rules/pull/51

Closes https://github.com/fireeye/capa/issues/194