### PR TITLE
rules: add support for arch flavors of Number and Offset features

### DIFF
--- a/capa/features/__init__.py
+++ b/capa/features/__init__.py
@@ -16,6 +16,12 @@ import capa.engine
 logger = logging.getLogger(__name__)
 MAX_BYTES_FEATURE_SIZE = 0x100
 
+# identifiers for supported architectures names that tweak a feature
+# for example, offset/x32
+ARCH_X32 = "x32"
+ARCH_X64 = "x64"
+VALID_ARCH = (ARCH_X32, ARCH_X64)
+
 
 def bytes_to_str(b):
     if sys.version_info[0] >= 3:
@@ -30,21 +36,42 @@ def hex_string(h):
 
 
 class Feature(object):
-    def __init__(self, value, description=None):
+    def __init__(self, value, arch=None, description=None):
+        """
+        Args:
+          value (any): the value of the feature, such as the number or string.
+          arch (str): one of the VALID_ARCH values, or None.
+            When None, then the feature applies to any architecture.
+            Modifies the feature name from `feature` to `feature/arch`, like `offset/x32`.
+          description (str): a human-readable description that explains the feature value.
+        """
         super(Feature, self).__init__()
-        self.name = self.__class__.__name__.lower()
+
+        if arch is not None:
+            if arch not in VALID_ARCH:
+                print(value, arch, description)
+                raise ValueError("arch '%s' must be one of %s" % (arch, VALID_ARCH))
+            self.name = self.__class__.__name__.lower() + "/" + arch
+        else:
+            self.name = self.__class__.__name__.lower()
+
         self.value = value
+        self.arch = arch
         self.description = description
 
     def __hash__(self):
-        return hash((self.name, self.value))
+        return hash((self.name, self.value, self.arch))
 
     def __eq__(self, other):
-        return self.name == other.name and self.value == other.value
+        return self.name == other.name and self.value == other.value and self.arch == other.arch
 
-    # Used to overwrite the rendering of the feature value in `__str__` and the
-    # json output
     def get_value_str(self):
+        """
+        render the value of this feature, for use by `__str__` and friends.
+        subclasses should override to customize the rendering.
+
+        Returns: any
+        """
         return self.value
 
     def __str__(self):
@@ -62,36 +89,44 @@ class Feature(object):
     def evaluate(self, ctx):
         return capa.engine.Result(self in ctx, self, [], locations=ctx.get(self, []))
 
-    def serialize(self):
-        return self.__dict__
-
     def freeze_serialize(self):
-        return (self.__class__.__name__, [self.value])
+        if self.arch is not None:
+            return (self.__class__.__name__, [self.value, {"arch": self.arch}])
+        else:
+            return (self.__class__.__name__, [self.value])
 
     @classmethod
     def freeze_deserialize(cls, args):
-        return cls(*args)
+        # as you can see below in code,
+        # if the last argument is a dictionary,
+        # consider it to be kwargs passed to the feature constructor.
+        if len(args) == 1:
+            return cls(*args)
+        elif isinstance(args[-1], dict):
+            kwargs = args[-1]
+            args = args[:-1]
+            return cls(*args, **kwargs)
 
 
 class MatchedRule(Feature):
     def __init__(self, value, description=None):
-        super(MatchedRule, self).__init__(value, description)
+        super(MatchedRule, self).__init__(value, description=description)
         self.name = "match"
 
 
 class Characteristic(Feature):
     def __init__(self, value, description=None):
-        super(Characteristic, self).__init__(value, description)
+        super(Characteristic, self).__init__(value, description=description)
 
 
 class String(Feature):
     def __init__(self, value, description=None):
-        super(String, self).__init__(value, description)
+        super(String, self).__init__(value, description=description)
 
 
 class Regex(String):
     def __init__(self, value, description=None):
-        super(Regex, self).__init__(value, description)
+        super(Regex, self).__init__(value, description=description)
         pat = self.value[len("/") : -len("/")]
         flags = re.DOTALL
         if value.endswith("/i"):
@@ -129,13 +164,13 @@ class Regex(String):
 class StringFactory(object):
     def __new__(self, value, description):
         if value.startswith("/") and (value.endswith("/") or value.endswith("/i")):
-            return Regex(value, description)
-        return String(value, description)
+            return Regex(value, description=description)
+        return String(value, description=description)
 
 
 class Bytes(Feature):
     def __init__(self, value, description=None):
-        super(Bytes, self).__init__(value, description)
+        super(Bytes, self).__init__(value, description=description)
 
     def evaluate(self, ctx):
         for feature, locations in ctx.items():

--- a/capa/features/__init__.py
+++ b/capa/features/__init__.py
@@ -49,7 +49,6 @@ class Feature(object):
 
         if arch is not None:
             if arch not in VALID_ARCH:
-                print(value, arch, description)
                 raise ValueError("arch '%s' must be one of %s" % (arch, VALID_ARCH))
             self.name = self.__class__.__name__.lower() + "/" + arch
         else:

--- a/capa/features/extractors/ida/insn.py
+++ b/capa/features/extractors/ida/insn.py
@@ -12,10 +12,21 @@ import idautils
 
 import capa.features.extractors.helpers
 import capa.features.extractors.ida.helpers
-from capa.features import MAX_BYTES_FEATURE_SIZE, Bytes, String, Characteristic
+from capa.features import ARCH_X32, ARCH_X64, MAX_BYTES_FEATURE_SIZE, Bytes, String, Characteristic
 from capa.features.insn import Number, Offset, Mnemonic
 
 _file_imports_cache = None
+
+
+def get_arch():
+    # https://reverseengineering.stackexchange.com/a/11398/17194
+    info = idaapi.get_inf_structure()
+    if info.is_64bit():
+        return ARCH_X64
+    elif info.is_32bit():
+        return ARCH_X32
+    else:
+        raise ValueError("unexpected architecture")
 
 
 def get_imports():
@@ -88,6 +99,7 @@ def extract_insn_number_features(f, bb, insn):
         const = capa.features.extractors.ida.helpers.mask_op_val(op)
         if not idaapi.is_mapped(const):
             yield Number(const), insn.ea
+            yield Number(const, arch=get_arch()), insn.ea
 
 
 def extract_insn_bytes_features(f, bb, insn):
@@ -155,6 +167,7 @@ def extract_insn_offset_features(f, bb, insn):
         op_off = capa.features.extractors.helpers.twos_complement(op_off, 32)
 
         yield Offset(op_off), insn.ea
+        yield Offset(op_off, arch=get_arch()), insn.ea
 
 
 def contains_stack_cookie_keywords(s):

--- a/capa/features/extractors/ida/insn.py
+++ b/capa/features/extractors/ida/insn.py
@@ -19,7 +19,13 @@ _file_imports_cache = None
 
 
 def get_arch():
-    # https://reverseengineering.stackexchange.com/a/11398/17194
+    """
+    fetch the ARCH_* constant for the currently open workspace.
+    we expect this routine to be pretty lightweight, so we don't cache it.
+
+    via Tamir Bahar/@tmr232
+    https://reverseengineering.stackexchange.com/a/11398/17194
+    """
     info = idaapi.get_inf_structure()
     if info.is_64bit():
         return ARCH_X64

--- a/capa/features/file.py
+++ b/capa/features/file.py
@@ -12,16 +12,16 @@ from capa.features import Feature
 class Export(Feature):
     def __init__(self, value, description=None):
         # value is export name
-        super(Export, self).__init__(value, description)
+        super(Export, self).__init__(value, description=description)
 
 
 class Import(Feature):
     def __init__(self, value, description=None):
         # value is import name
-        super(Import, self).__init__(value, description)
+        super(Import, self).__init__(value, description=description)
 
 
 class Section(Feature):
     def __init__(self, value, description=None):
         # value is section name
-        super(Section, self).__init__(value, description)
+        super(Section, self).__init__(value, description=description)

--- a/capa/features/insn.py
+++ b/capa/features/insn.py
@@ -20,16 +20,16 @@ class API(Feature):
 
 
 class Number(Feature):
-    def __init__(self, value, description=None):
-        super(Number, self).__init__(value, description)
+    def __init__(self, value, arch=None, description=None):
+        super(Number, self).__init__(value, arch=arch, description=description)
 
     def get_value_str(self):
         return "0x%X" % self.value
 
 
 class Offset(Feature):
-    def __init__(self, value, description=None):
-        super(Offset, self).__init__(value, description)
+    def __init__(self, value, arch=None, description=None):
+        super(Offset, self).__init__(value, arch=arch, description=description)
 
     def get_value_str(self):
         return "0x%X" % self.value
@@ -37,4 +37,4 @@ class Offset(Feature):
 
 class Mnemonic(Feature):
     def __init__(self, value, description=None):
-        super(Mnemonic, self).__init__(value, description)
+        super(Mnemonic, self).__init__(value, description=description)

--- a/capa/rules.py
+++ b/capa/rules.py
@@ -10,6 +10,7 @@ import uuid
 import codecs
 import logging
 import binascii
+import functools
 
 import six
 import ruamel.yaml
@@ -197,12 +198,18 @@ def parse_feature(key):
         return capa.features.insn.Number
     elif key.startswith("number/"):
         arch = key.partition("/")[2]
-        return lambda *args, **kwargs: capa.features.insn.Number(*args, arch=arch, **kwargs)
+        # the other handlers here return constructors for features,
+        # and we want to as well,
+        # however, we need to preconfigure one of the arguments (`arch`).
+        # so, instead we return a partially-applied function that
+        #  provides `arch` to the feature constructor.
+        # it forwards any other arguments provided to the closure along to the constructor.
+        return functools.partial(capa.features.insn.Number, arch=arch)
     elif key == "offset":
         return capa.features.insn.Offset
     elif key.startswith("offset/"):
         arch = key.partition("/")[2]
-        return lambda *args, **kwargs: capa.features.insn.Offset(*args, arch=arch, **kwargs)
+        return functools.partial(capa.features.insn.Offset, arch=arch)
     elif key == "mnemonic":
         return capa.features.insn.Mnemonic
     elif key == "basic blocks":

--- a/capa/rules.py
+++ b/capa/rules.py
@@ -195,8 +195,14 @@ def parse_feature(key):
         return capa.features.Bytes
     elif key == "number":
         return capa.features.insn.Number
+    elif key.startswith("number/"):
+        arch = key.partition("/")[2]
+        return lambda *args, **kwargs: capa.features.insn.Number(*args, arch=arch, **kwargs)
     elif key == "offset":
         return capa.features.insn.Offset
+    elif key.startswith("offset/"):
+        arch = key.partition("/")[2]
+        return lambda *args, **kwargs: capa.features.insn.Offset(*args, arch=arch, **kwargs)
     elif key == "mnemonic":
         return capa.features.insn.Mnemonic
     elif key == "basic blocks":
@@ -325,7 +331,7 @@ def build_statements(d, scope):
             #     count(number(0x100 = description))
             if term != "string":
                 value, description = parse_description(arg, term)
-                feature = Feature(value, description)
+                feature = Feature(value, description=description)
             else:
                 # arg is string (which doesn't support inline descriptions), like:
                 #
@@ -358,7 +364,7 @@ def build_statements(d, scope):
         Feature = parse_feature(key)
         value, description = parse_description(d[key], key, d.get("description"))
         try:
-            feature = Feature(value, description)
+            feature = Feature(value, description=description)
         except ValueError as e:
             raise InvalidRule(str(e))
         ensure_feature_valid_for_scope(scope, feature)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -444,3 +444,15 @@ def test_match_namespace():
     assert "WriteFile API" in matches
     assert "file-create" not in matches
     assert "filesystem-any" in matches
+
+
+def test_render_number():
+    assert str(capa.features.insn.Number(1)) == "number(0x1)"
+    assert str(capa.features.insn.Number(1, arch=ARCH_X32)) == "number/x32(0x1)"
+    assert str(capa.features.insn.Number(1, arch=ARCH_X64)) == "number/x64(0x1)"
+
+
+def test_render_offset():
+    assert str(capa.features.insn.Offset(1)) == "offset(0x1)"
+    assert str(capa.features.insn.Offset(1, arch=ARCH_X32)) == "offset/x32(0x1)"
+    assert str(capa.features.insn.Offset(1, arch=ARCH_X64)) == "offset/x64(0x1)"

--- a/tests/test_viv_features.py
+++ b/tests/test_viv_features.py
@@ -17,6 +17,7 @@ import capa.features.extractors.viv.file
 import capa.features.extractors.viv.insn
 import capa.features.extractors.viv.function
 import capa.features.extractors.viv.basicblock
+from capa.features import ARCH_X32, ARCH_X64
 
 
 def extract_file_features(vw, path):
@@ -108,6 +109,13 @@ def test_number_features(mimikatz):
     assert capa.features.insn.Number(0x10) not in features
 
 
+def test_number_arch_features(mimikatz):
+    features = extract_function_features(viv_utils.Function(mimikatz.vw, 0x40105D))
+    assert capa.features.insn.Number(0xFF) in features
+    assert capa.features.insn.Number(0xFF, arch=ARCH_X32) in features
+    assert capa.features.insn.Number(0xFF, arch=ARCH_X64) not in features
+
+
 def test_offset_features(mimikatz):
     features = extract_function_features(viv_utils.Function(mimikatz.vw, 0x40105D))
     assert capa.features.insn.Offset(0x0) in features
@@ -123,6 +131,13 @@ def test_offset_features(mimikatz):
     features = extract_function_features(viv_utils.Function(mimikatz.vw, 0x4011FB))
     assert capa.features.insn.Offset(-0x1) in features
     assert capa.features.insn.Offset(-0x2) in features
+
+
+def test_offset_arch_features(mimikatz):
+    features = extract_function_features(viv_utils.Function(mimikatz.vw, 0x40105D))
+    assert capa.features.insn.Offset(0x0) in features
+    assert capa.features.insn.Offset(0x0, arch=ARCH_X32) in features
+    assert capa.features.insn.Offset(0x0, arch=ARCH_X64) not in features
 
 
 def test_nzxor_features(mimikatz):


### PR DESCRIPTION
I added the arch flavor directly to the `Feature` base class since this meant the smallest delta and duplication of code. In theory, this means we could add arch-specific strings/regex/bytes/mnemonics/etc. easily; however, we don't have any plans to do so. In this PR, the freeze format is extended a bit - kwargs to the Feature constructors end up in a final dictionary "argument". This is not a breaking change. 

closes #210