### PR TITLE
Fix build workflow & zip binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
             asset_name: capa-linux
           - os: windows-latest
             artifact_name: capa.exe
-            asset_name: capa-windows.exe
+            asset_name: capa-windows
           - os: macos-latest
             artifact_name: capa
             asset_name: capa-macos
@@ -42,11 +42,33 @@ jobs:
         with:
           name: ${{ matrix.asset_name }}
           path: dist/${{ matrix.artifact_name }}
-      - name: Upload binaries to GH Release
+
+  zip:
+    name: zip ${{ matrix.asset_name }}
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - asset_name: capa-linux
+            artifact_name: capa
+          - asset_name: capa-windows
+            artifact_name: capa.exe
+          - asset_name: capa-macos
+            artifact_name: capa
+    steps:
+      - name: Download ${{ matrix.asset_name }}
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.asset_name }}
+      - name: Set executable flag
+        run: chmod +x ${{ matrix.artifact_name }}
+      - name: Zip ${{ matrix.artifact_name }} into ${{ matrix.asset_name }}.zip
+        run: zip ${{ matrix.asset_name }}.zip ${{ matrix.artifact_name }}
+      - name: Upload ${{ matrix.asset_name }}.zip to GH Release
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/${{ matrix.artifact_name }}
-          asset_name: ${{ matrix.asset_name }}
+          repo_token: ${{ secrets.GITHUB_TOKEN}}
+          file: ${{ matrix.asset_name }}.zip
           tag: ${{ github.ref }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,8 @@ jobs:
         with:
           python-version: 2.7
       - name: Install PyInstaller
-        run: pip install pyinstaller
+        # pyinstaller 4 doesn't support Python 2.7
+        run: pip install 'pyinstaller==3.*'
       - name: Install capa
         run: pip install -e .
       - name: Build standalone executable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,8 @@ jobs:
     - name: Upload binaries to GH Release
       uses: svenstaro/upload-release-action@v2
       with:
-        repo_token: ${{ secrets.CAPA_TOKEN }}
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: dist/${{ matrix.artifact_name }}
         asset_name: ${{ matrix.asset_name }}
         tag: ${{ github.ref }}
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,31 +22,31 @@ jobs:
             artifact_name: capa
             asset_name: capa-macos
     steps:
-    - name: Checkout capa
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-    - name: Set up Python 2.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: 2.7
-    - name: Install PyInstaller
-      run: pip install pyinstaller
-    - name: Install capa
-      run: pip install -e .
-    - name: Build standalone executable
-      run: pyinstaller .github/pyinstaller/pyinstaller.spec
-    - name: Does it run?
-      run: dist/capa "tests/data/Practical Malware Analysis Lab 01-01.dll_"
-    - uses: actions/upload-artifact@v2
-      with:
-        name: ${{ matrix.asset_name }}
-        path: dist/${{ matrix.artifact_name }}
-    - name: Upload binaries to GH Release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: dist/${{ matrix.artifact_name }}
-        asset_name: ${{ matrix.asset_name }}
-        tag: ${{ github.ref }}
+      - name: Checkout capa
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up Python 2.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 2.7
+      - name: Install PyInstaller
+        run: pip install pyinstaller
+      - name: Install capa
+        run: pip install -e .
+      - name: Build standalone executable
+        run: pyinstaller .github/pyinstaller/pyinstaller.spec
+      - name: Does it run?
+        run: dist/capa "tests/data/Practical Malware Analysis Lab 01-01.dll_"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.asset_name }}
+          path: dist/${{ matrix.artifact_name }}
+      - name: Upload binaries to GH Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/${{ matrix.artifact_name }}
+          asset_name: ${{ matrix.asset_name }}
+          tag: ${{ github.ref }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,13 @@ jobs:
           - os: ubuntu-16.04
             # use old linux so that the shared library versioning is more portable
             artifact_name: capa
-            asset_name: capa-linux
+            asset_name: linux
           - os: windows-latest
             artifact_name: capa.exe
-            asset_name: capa-windows
+            asset_name: windows
           - os: macos-latest
             artifact_name: capa
-            asset_name: capa-macos
+            asset_name: macos
     steps:
       - name: Checkout capa
         uses: actions/checkout@v2
@@ -51,11 +51,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - asset_name: capa-linux
+          - asset_name: linux
             artifact_name: capa
-          - asset_name: capa-windows
+          - asset_name: windows
             artifact_name: capa.exe
-          - asset_name: capa-macos
+          - asset_name: macos
             artifact_name: capa
     steps:
       - name: Download ${{ matrix.asset_name }}
@@ -64,12 +64,14 @@ jobs:
           name: ${{ matrix.asset_name }}
       - name: Set executable flag
         run: chmod +x ${{ matrix.artifact_name }}
-      - name: Zip ${{ matrix.artifact_name }} into ${{ matrix.asset_name }}.zip
-        run: zip ${{ matrix.asset_name }}.zip ${{ matrix.artifact_name }}
-      - name: Upload ${{ matrix.asset_name }}.zip to GH Release
+      - name: Set zip name
+        run: echo ::set-env name=zip_name::capa-${GITHUB_REF#refs/tags/}-${{ matrix.asset_name }}.zip
+      - name: Zip ${{ matrix.artifact_name }} into ${{ env.zip_name }}
+        run: zip ${{ env.zip_name }} ${{ matrix.artifact_name }}
+      - name: Upload ${{ env.zip_name }} to GH Release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN}}
-          file: ${{ matrix.asset_name }}.zip
+          file: ${{ env.zip_name }}
           tag: ${{ github.ref }}
 


### PR DESCRIPTION
The build workflow is currently broken due to the release of pyinstaller 4 which doesn't support Python 2.7. Fix pyinstaller to version 3 to fix it.

Zip binaries before uploading them to the release to be able to keep the executable flag. To do this I am using `actions/upload-artifact` to upload every of the binaries and `actions/download-artifact` to download them in ubuntu-latest. By doing this, we can zip all the binaries in the same way. The only disadvantage is that the executable flag gets lost in the upload/download and we need to set it again.

At first I wanted to use [`montudor/action-zip`](https://github.com/montudor/action-zip)  for this, but then I realised that `zip` is install in the used ubuntu image. 

You can see it working here:
https://github.com/Ana06/capa/releases/tag/ana
https://github.com/Ana06/capa/actions/runs/209736794

![Screen Shot 2020-08-15 at 12 50 04](https://user-images.githubusercontent.com/16052290/90310873-e6dfc580-def5-11ea-8175-c79b58eac1b1.png)
