### PR TITLE
backport py3 testing enhancements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Run rule linter
       run: python scripts/lint.py rules/
 
-  tests:
+  tests27:
     runs-on: ubuntu-latest
     needs: [code_style, rule_linter]
     steps:
@@ -52,6 +52,23 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 2.7
+    - name: Install capa
+      run: pip install -e .[dev]
+    - name: Run tests
+      run: pytest tests/
+
+  tests38:
+    runs-on: ubuntu-latest
+    needs: [code_style, rule_linter]
+    steps:
+    - name: Checkout capa with submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
     - name: Install capa
       run: pip install -e .[dev]
     - name: Run tests

--- a/capa/features/freeze.py
+++ b/capa/features/freeze.py
@@ -101,7 +101,9 @@ def dumps(extractor):
             for feature, va in extractor.extract_basic_block_features(f, bb):
                 ret["scopes"]["basic block"].append(serialize_feature(feature) + (hex(va), (hex(f), hex(bb),)))
 
-            for insn, insnva in sorted([(insn, int(insn)) for insn in extractor.get_instructions(f, bb)]):
+            for insnva, insn in sorted(
+                [(insn.__int__(), insn) for insn in extractor.get_instructions(f, bb)], key=lambda p: p[0]
+            ):
                 ret["functions"][hex(f)][hex(bb)].append(hex(insnva))
 
                 for feature, va in extractor.extract_insn_features(f, bb, insn):
@@ -245,12 +247,7 @@ def main(argv=None):
         logging.basicConfig(level=logging.INFO)
         logging.getLogger().setLevel(logging.INFO)
 
-    vw = capa.main.get_workspace(args.sample, args.format)
-
-    # don't import this at top level to support ida/py3 backend
-    import capa.features.extractors.viv
-
-    extractor = capa.features.extractors.viv.VivisectFeatureExtractor(vw, args.sample)
+    extractor = capa.main.get_extractor(args.sample, args.format)
     with open(args.output, "wb") as f:
         f.write(dump(extractor))
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -80,16 +80,6 @@ def get_viv_extractor(path):
     return capa.features.extractors.viv.VivisectFeatureExtractor(vw, path)
 
 
-@lru_cache
-def get_lancelot_extractor(path):
-    import capa.features.extractors.lancelot
-
-    with open(path, "rb") as f:
-        buf = f.read()
-
-    return capa.features.extractors.lancelot.LancelotFeatureExtractor(buf)
-
-
 @lru_cache()
 def extract_file_features(extractor):
     features = collections.defaultdict(set)
@@ -437,7 +427,7 @@ def do_test_feature_count(get_extractor, sample, scope, feature, expected):
 
 def get_extractor(path):
     if sys.version_info >= (3, 0):
-        extractor = get_lancelot_extractor(path)
+        raise RuntimeError("no supported py3 backends yet")
     else:
         extractor = get_viv_extractor(path)
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -7,6 +7,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 import os
+import sys
 import os.path
 import collections
 
@@ -38,6 +39,16 @@ def get_viv_extractor(path):
     else:
         vw = capa.main.get_workspace(path, "auto", should_save=True)
     return capa.features.extractors.viv.VivisectFeatureExtractor(vw, path)
+
+
+@lru_cache
+def get_lancelot_extractor(path):
+    import capa.features.extractors.lancelot
+
+    with open(path, "rb") as f:
+        buf = f.read()
+
+    return capa.features.extractors.lancelot.LancelotFeatureExtractor(buf)
 
 
 @lru_cache()
@@ -386,9 +397,10 @@ def do_test_feature_count(get_extractor, sample, scope, feature, expected):
 
 
 def get_extractor(path):
-    # decide here which extractor to load for tests.
-    # maybe check which python version we've loaded or if we're in IDA.
-    extractor = get_viv_extractor(path)
+    if sys.version_info >= (3, 0):
+        extractor = get_lancelot_extractor(path)
+    else:
+        extractor = get_viv_extractor(path)
 
     # overload the extractor so that the fixture exposes `extractor.path`
     setattr(extractor, "path", path)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -376,7 +376,12 @@ def do_test_feature_presence(get_extractor, sample, scope, feature, expected):
 def do_test_feature_count(get_extractor, sample, scope, feature, expected):
     extractor = get_extractor(sample)
     features = scope(extractor)
-    msg = "%s should be found %d times in %s" % (str(feature), expected, scope.__name__)
+    msg = "%s should be found %d times in %s, found: %d" % (
+        str(feature),
+        expected,
+        scope.__name__,
+        len(features[feature]),
+    )
     assert len(features[feature]) == expected, msg
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -43,7 +43,7 @@ def xfail(condition, reason=None):
         #  - fails  on py3 if foo() fails
         #  - xfails on py2 if foo() fails
         #  - fails  on py2 if foo() works
-        with xfail(sys.version_info < (3, 0), reason="py3 doesn't foo"):
+        with xfail(sys.version_info < (3, 0), reason="py2 doesn't foo"):
             foo()
     """
     try:

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -6,10 +6,9 @@
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 import sys
-
-import pytest
 import textwrap
 
+import pytest
 from fixtures import *
 
 import capa.main

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -104,17 +104,14 @@ def compare_extractors_viv_null(viv_ext, null_ext):
       viv_ext (capa.features.extractors.viv.VivisectFeatureExtractor)
       null_ext (capa.features.extractors.NullFeatureExtractor)
     """
-
-    # TODO: ordering of these things probably doesn't work yet
-
     assert list(viv_ext.extract_file_features()) == list(null_ext.extract_file_features())
-    assert to_int(list(viv_ext.get_functions())) == list(null_ext.get_functions())
+    assert list(map(to_int, viv_ext.get_functions())) == list(null_ext.get_functions())
     for f in viv_ext.get_functions():
-        assert to_int(list(viv_ext.get_basic_blocks(f))) == list(null_ext.get_basic_blocks(to_int(f)))
+        assert list(map(to_int, viv_ext.get_basic_blocks(f))) == list(null_ext.get_basic_blocks(to_int(f)))
         assert list(viv_ext.extract_function_features(f)) == list(null_ext.extract_function_features(to_int(f)))
 
         for bb in viv_ext.get_basic_blocks(f):
-            assert to_int(list(viv_ext.get_instructions(f, bb))) == list(
+            assert list(map(to_int, viv_ext.get_instructions(f, bb))) == list(
                 null_ext.get_instructions(to_int(f), to_int(bb))
             )
             assert list(viv_ext.extract_basic_block_features(f, bb)) == list(
@@ -129,10 +126,7 @@ def compare_extractors_viv_null(viv_ext, null_ext):
 
 def to_int(o):
     """helper to get int value of extractor items"""
-    if isinstance(o, list):
-        return map(lambda x: capa.helpers.oint(x), o)
-    else:
-        return capa.helpers.oint(o)
+    return capa.helpers.oint(o)
 
 
 def test_freeze_s_roundtrip():

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -5,7 +5,9 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+import sys
 
+import pytest
 import textwrap
 
 from fixtures import *
@@ -163,6 +165,7 @@ def test_serialize_features():
     roundtrip_feature(capa.features.file.Import("#11"))
 
 
+@pytest.mark.xfail(sys.version_info >= (3, 0), reason="vivsect only works on py2")
 def test_freeze_sample(tmpdir, z9324d_extractor):
     # tmpdir fixture handles cleanup
     o = tmpdir.mkdir("capa").join("test.frz").strpath
@@ -170,6 +173,7 @@ def test_freeze_sample(tmpdir, z9324d_extractor):
     assert capa.features.freeze.main([path, o, "-v"]) == 0
 
 
+@pytest.mark.xfail(sys.version_info >= (3, 0), reason="vivsect only works on py2")
 def test_freeze_load_sample(tmpdir, z9324d_extractor):
     o = tmpdir.mkdir("capa").join("test.frz")
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,10 +5,10 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+import sys
 
+import pytest
 import textwrap
-
-from fixtures import *
 
 import capa.main
 import capa.rules
@@ -16,7 +16,9 @@ import capa.engine
 import capa.features
 from capa.engine import *
 
+from fixtures import *
 
+@pytest.mark.xfail(sys.version_info >= (3, 0), reason="vivsect only works on py2")
 def test_main(z9324d_extractor):
     # tests rules can be loaded successfully and all output modes
     path = z9324d_extractor.path
@@ -26,6 +28,7 @@ def test_main(z9324d_extractor):
     assert capa.main.main([path]) == 0
 
 
+@pytest.mark.xfail(sys.version_info >= (3, 0), reason="vivsect only works on py2")
 def test_main_single_rule(z9324d_extractor, tmpdir):
     # tests a single rule can be loaded successfully
     RULE_CONTENT = textwrap.dedent(
@@ -44,6 +47,7 @@ def test_main_single_rule(z9324d_extractor, tmpdir):
     assert capa.main.main([path, "-v", "-r", rule_file.strpath,]) == 0
 
 
+@pytest.mark.xfail(sys.version_info >= (3, 0), reason="vivsect only works on py2")
 def test_main_shellcode(z499c2_extractor):
     path = z499c2_extractor.path
     assert capa.main.main([path, "-vv", "-f", "sc32"]) == 0
@@ -98,6 +102,7 @@ def test_ruleset():
     assert len(rules.basic_block_rules) == 1
 
 
+@pytest.mark.xfail(sys.version_info >= (3, 0), reason="vivsect only works on py2")
 def test_match_across_scopes_file_function(z9324d_extractor):
     rules = capa.rules.RuleSet(
         [
@@ -161,6 +166,7 @@ def test_match_across_scopes_file_function(z9324d_extractor):
     assert ".text section and install service" in capabilities
 
 
+@pytest.mark.xfail(sys.version_info >= (3, 0), reason="vivsect only works on py2")
 def test_match_across_scopes(z9324d_extractor):
     rules = capa.rules.RuleSet(
         [
@@ -223,6 +229,7 @@ def test_match_across_scopes(z9324d_extractor):
     assert "kill thread program" in capabilities
 
 
+@pytest.mark.xfail(sys.version_info >= (3, 0), reason="vivsect only works on py2")
 def test_subscope_bb_rules(z9324d_extractor):
     rules = capa.rules.RuleSet(
         [
@@ -247,6 +254,7 @@ def test_subscope_bb_rules(z9324d_extractor):
     assert "test rule" in capabilities
 
 
+@pytest.mark.xfail(sys.version_info >= (3, 0), reason="vivsect only works on py2")
 def test_byte_matching(z9324d_extractor):
     rules = capa.rules.RuleSet(
         [
@@ -269,6 +277,7 @@ def test_byte_matching(z9324d_extractor):
     assert "byte match test" in capabilities
 
 
+@pytest.mark.xfail(sys.version_info >= (3, 0), reason="vivsect only works on py2")
 def test_count_bb(z9324d_extractor):
     rules = capa.rules.RuleSet(
         [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,7 +14,6 @@ import capa.main
 import capa.rules
 import capa.engine
 import capa.features
-import capa.features.extractors.viv
 from capa.engine import *
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,9 +6,10 @@
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 import sys
+import textwrap
 
 import pytest
-import textwrap
+from fixtures import *
 
 import capa.main
 import capa.rules
@@ -16,7 +17,6 @@ import capa.engine
 import capa.features
 from capa.engine import *
 
-from fixtures import *
 
 @pytest.mark.xfail(sys.version_info >= (3, 0), reason="vivsect only works on py2")
 def test_main(z9324d_extractor):

--- a/tests/test_viv_features.py
+++ b/tests/test_viv_features.py
@@ -5,6 +5,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+import sys
 
 from fixtures import *
 
@@ -13,11 +14,13 @@ from fixtures import *
     "sample,scope,feature,expected", FEATURE_PRESENCE_TESTS, indirect=["sample", "scope"],
 )
 def test_viv_features(sample, scope, feature, expected):
-    do_test_feature_presence(get_viv_extractor, sample, scope, feature, expected)
+    with xfail(sys.version_info >= (3, 0), reason="vivsect only works on py2"):
+        do_test_feature_presence(get_viv_extractor, sample, scope, feature, expected)
 
 
 @parametrize(
     "sample,scope,feature,expected", FEATURE_COUNT_TESTS, indirect=["sample", "scope"],
 )
 def test_viv_feature_counts(sample, scope, feature, expected):
-    do_test_feature_count(get_viv_extractor, sample, scope, feature, expected)
+    with xfail(sys.version_info >= (3, 0), reason="vivsect only works on py2"):
+        do_test_feature_count(get_viv_extractor, sample, scope, feature, expected)


### PR DESCRIPTION
backport py3 testing enhancements from #234. basically: wrap py2-only things in xfail annotations.

when we add a py3 backend, then all we need to do is update `fixtures::get_extractor()` to return the py3 backend on py3 and then re-run the tests. pytest will complain that things that we used to fail no longer fail, so go through and remove those xfail marks.

![image](https://user-images.githubusercontent.com/156560/90453940-230a5600-e0af-11ea-9bf4-c7db89bad664.png)
