### PR TITLE
Add Miasm backend (Python3 support in terminal)

### DIFF
--- a/capa/features/extractors/__init__.py
+++ b/capa/features/extractors/__init__.py
@@ -8,6 +8,8 @@
 
 import abc
 
+from capa.helpers import oint
+
 
 class FeatureExtractor(object):
     """
@@ -34,6 +36,12 @@ class FeatureExtractor(object):
         # this base class doesn't know what to do with that info, though.
         #
         super(FeatureExtractor, self).__init__()
+
+    def block_offset(self, bb):
+        return oint(bb)
+
+    def function_offset(self, f):
+        return oint(f)
 
     @abc.abstractmethod
     def get_base_address(self):

--- a/capa/features/extractors/miasm/__init__.py
+++ b/capa/features/extractors/miasm/__init__.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2020 FireEye, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at: https://github.com/fireeye/capa/blob/master/LICENSE.txt
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+import miasm.analysis.binary
+
+import capa.features.extractors.miasm.file
+from capa.features.extractors import FeatureExtractor
+
+
+class MiasmFeatureExtractor(FeatureExtractor):
+    def __init__(self, buf):
+        super(MiasmFeatureExtractor, self).__init__()
+        self.buf = buf
+        self.container = miasm.analysis.binary.Container.from_string(buf)
+        self.pe = self.container.executable
+
+    def get_base_address(self):
+        return self.container.entry_point
+
+    def extract_file_features(self):
+        for feature, va in capa.features.extractors.miasm.file.extract_file_features(self.buf, self.pe):
+            yield feature, va
+
+    def get_functions(self):
+        raise NotImplementedError()
+
+    def extract_function_features(self, f):
+        raise NotImplementedError()
+
+    def get_basic_blocks(self, f):
+        raise NotImplementedError()
+
+    def extract_basic_block_features(self, f, bb):
+        raise NotImplementedError()
+
+    def get_instructions(self, f, bb):
+        raise NotImplementedError()
+
+    def extract_insn_features(self, f, bb, insn):
+        raise NotImplementedError()

--- a/capa/features/extractors/miasm/__init__.py
+++ b/capa/features/extractors/miasm/__init__.py
@@ -10,6 +10,7 @@ import miasm.analysis.binary
 import miasm.analysis.machine
 
 import capa.features.extractors.miasm.file
+import capa.features.extractors.miasm.function
 import capa.features.extractors.miasm.basicblock
 from capa.features.extractors import FeatureExtractor
 
@@ -45,8 +46,9 @@ class MiasmFeatureExtractor(FeatureExtractor):
                         functions.add(loc_key)
                         yield loc_key
 
-    def extract_function_features(self, f):
-        raise NotImplementedError()
+    def extract_function_features(self, loc_key):
+        for feature, va in capa.features.extractors.miasm.function.extract_features(self, loc_key):
+            yield feature, va
 
     def block_offset(self, bb):
         return bb.lines[0].offset

--- a/capa/features/extractors/miasm/__init__.py
+++ b/capa/features/extractors/miasm/__init__.py
@@ -54,6 +54,9 @@ class MiasmFeatureExtractor(FeatureExtractor):
     def block_offset(self, bb):
         return bb.lines[0].offset
 
+    def function_offset(self, f):
+        return self.cfg.loc_key_to_block(f).lines[0].offset
+
     def get_basic_blocks(self, loc_key):
         """
         get the basic blocks of the function represented by lock_key

--- a/capa/features/extractors/miasm/__init__.py
+++ b/capa/features/extractors/miasm/__init__.py
@@ -10,6 +10,7 @@ import miasm.analysis.binary
 import miasm.analysis.machine
 
 import capa.features.extractors.miasm.file
+import capa.features.extractors.miasm.insn
 import capa.features.extractors.miasm.function
 import capa.features.extractors.miasm.basicblock
 from capa.features.extractors import FeatureExtractor
@@ -66,11 +67,12 @@ class MiasmFeatureExtractor(FeatureExtractor):
         for feature, va in capa.features.extractors.miasm.basicblock.extract_features(bb):
             yield feature, va
 
-    def get_instructions(self, f, bb):
-        raise NotImplementedError()
+    def get_instructions(self, _, bb):
+        return bb.lines
 
     def extract_insn_features(self, f, bb, insn):
-        raise NotImplementedError()
+        for feature, va in capa.features.extractors.miasm.insn.extract_features(self, f, bb, insn):
+            yield feature, va
 
     def _get_entry_points(self):
         entry_points = {self.get_base_address()}

--- a/capa/features/extractors/miasm/__init__.py
+++ b/capa/features/extractors/miasm/__init__.py
@@ -10,6 +10,7 @@ import miasm.analysis.binary
 import miasm.analysis.machine
 
 import capa.features.extractors.miasm.file
+import capa.features.extractors.miasm.basicblock
 from capa.features.extractors import FeatureExtractor
 
 
@@ -59,8 +60,9 @@ class MiasmFeatureExtractor(FeatureExtractor):
         cfg = disassembler.dis_multiblock(self.block_offset(block))
         return cfg.blocks
 
-    def extract_basic_block_features(self, f, bb):
-        raise NotImplementedError()
+    def extract_basic_block_features(self, _, bb):
+        for feature, va in capa.features.extractors.miasm.basicblock.extract_features(bb):
+            yield feature, va
 
     def get_instructions(self, f, bb):
         raise NotImplementedError()

--- a/capa/features/extractors/miasm/__init__.py
+++ b/capa/features/extractors/miasm/__init__.py
@@ -28,8 +28,20 @@ class MiasmFeatureExtractor(FeatureExtractor):
         for feature, va in capa.features.extractors.miasm.file.extract_file_features(self.buf, self.pe):
             yield feature, va
 
+    # TODO: Improve this function (it just considers all loc_keys target of calls a function), port to miasm
     def get_functions(self):
-        raise NotImplementedError()
+        """
+        returns all loc_keys which are the argument of any call function
+        """
+        functions = set()
+
+        for block in self.cfg.blocks:
+            for line in block.lines:
+                if line.is_subcall() and line.args[0].is_loc():
+                    loc_key = line.args[0].loc_key
+                    if loc_key not in functions:
+                        functions.add(loc_key)
+                        yield loc_key
 
     def extract_function_features(self, f):
         raise NotImplementedError()

--- a/capa/features/extractors/miasm/basicblock.py
+++ b/capa/features/extractors/miasm/basicblock.py
@@ -1,0 +1,134 @@
+# Copyright (C) 2020 FireEye, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at: https://github.com/fireeye/capa/blob/master/LICENSE.txt
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+import sys
+import string
+import struct
+
+from capa.features import Characteristic
+from capa.features.basicblock import BasicBlock
+from capa.features.extractors.helpers import MIN_STACKSTRING_LEN
+
+
+# TODO: Avoid this duplication (this code is in __init__ as well)
+def block_offset(bb):
+    return bb.lines[0].offset
+
+
+def extract_bb_tight_loop(bb):
+    """ check basic block for tight loop indicators """
+    if any(c.loc_key == bb.loc_key for c in bb.bto):
+        yield Characteristic("tight loop"), block_offset(bb)
+
+
+def is_mov_imm_to_stack(instr):
+    """
+    Return if instruction moves immediate onto stack
+    """
+    if not instr.name.startswith("MOV"):
+        return False
+
+    try:
+        dst, src = instr.args
+    except ValueError:
+        # not two operands
+        return False
+
+    if not src.is_int():
+        return False
+
+    if not dst.is_mem():
+        return False
+
+    # should detect things like `@8[ESP + 0x8]` and `EBP` and not fail in other cases
+    if any(register in str(dst) for register in ["EBP", "RBP", "ESP", "RSP"]):
+        return True
+
+    return False
+
+
+def is_printable_ascii(chars):
+    if sys.version_info >= (3, 0):
+        return all(c < 127 and chr(c) in string.printable for c in chars)
+    else:
+        return all(ord(c) < 127 and c in string.printable for c in chars)
+
+
+def is_printable_utf16le(chars):
+    if all(c == b"\x00" for c in chars[1::2]):
+        return is_printable_ascii(chars[::2])
+
+
+def get_printable_len(insn):
+    """
+    Return string length if all operand bytes are ascii or utf16-le printable
+    """
+    dst, src = insn.args
+
+    if not src.is_int():
+        return ValueError("unexpected operand type")
+
+    if not dst.is_mem():
+        return ValueError("unexpected operand type")
+
+    if isinstance(src.arg, int):
+        val = src.arg
+    else:
+        val = src.arg.arg
+
+    size = (val.bit_length() + 7) // 8
+
+    if size == 0:
+        return 0
+    elif size == 1:
+        chars = struct.pack("<B", val)
+    elif size == 2:
+        chars = struct.pack("<H", val)
+    elif size == 4:
+        chars = struct.pack("<I", val)
+    elif size == 8:
+        chars = struct.pack("<Q", val)
+
+    if is_printable_ascii(chars):
+        return size
+
+    if is_printable_utf16le(chars):
+        return size / 2
+
+    return 0
+
+
+def extract_stackstring(bb):
+    """ check basic block for stackstring indicators """
+    count = 0
+    for line in bb.lines:
+        if is_mov_imm_to_stack(line):
+            count += get_printable_len(line)
+        if count > MIN_STACKSTRING_LEN:
+            yield Characteristic("stack string"), block_offset(bb)
+            return
+
+
+def extract_features(bb):
+    """
+    extract features from the given basic block.
+    args:
+      bb (miasm.core.asmblock.AsmBlock): the basic block to process.
+    yields:
+      Feature, set[VA]: the features and their location found in this basic block.
+    """
+    yield BasicBlock(), block_offset(bb)
+    for bb_handler in BASIC_BLOCK_HANDLERS:
+        for feature, va in bb_handler(bb):
+            yield feature, va
+
+
+BASIC_BLOCK_HANDLERS = (
+    extract_bb_tight_loop,
+    extract_stackstring,
+)

--- a/capa/features/extractors/miasm/file.py
+++ b/capa/features/extractors/miasm/file.py
@@ -1,0 +1,101 @@
+# Copyright (C) 2020 FireEye, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at: https://github.com/fireeye/capa/blob/master/LICENSE.txt
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+import re
+
+import miasm.analysis.binary
+
+import capa.features.extractors.strings
+from capa.features import String, Characteristic
+from capa.features.file import Export, Import, Section
+
+
+def extract_file_embedded_pe(buf, _):
+    """
+    extract embedded PE features
+    """
+    for match in re.finditer(b"MZ", buf):
+        offset = match.start()
+        subcontainer = miasm.analysis.binary.ContainerPE.from_string(buf[offset:])
+        if isinstance(subcontainer, miasm.analysis.binary.ContainerPE):
+            yield Characteristic("embedded pe"), offset
+
+
+def extract_file_export_names(_, pe):
+    """
+    extract file exports and their addresses
+    """
+    for symbol, va in miasm.jitter.loader.pe.get_export_name_addr_list(pe):
+        # Only use func names and not ordinals
+        if isinstance(symbol, str):
+            yield Export(symbol), va
+
+
+def extract_file_import_names(_, pe):
+    """
+    extract imported function names and their addresses
+    1. imports by ordinal:
+     - modulename.#ordinal
+    2. imports by name, results in two features to support importname-only matching:
+     - modulename.importname
+     - importname
+    """
+    for ((dll, symbol), va_set) in miasm.jitter.loader.pe.get_import_address_pe(pe).items():
+        dll_name = dll[:-4]  # Remove .dll
+        for va in va_set:
+            if isinstance(symbol, int):
+                yield Import("%s.#%s" % (dll_name, symbol)), va
+            else:
+                yield Import("%s.%s" % (dll_name, symbol)), va
+                yield Import(symbol), va
+
+
+def extract_file_section_names(_, pe):
+    """
+    extract file sections and their addresses
+    """
+    for section in pe.SHList.shlist:
+        name = section.name.partition(b"\x00")[0].decode("ascii")
+        va = section.addr
+        yield Section(name), va
+
+
+def extract_file_strings(buf, _):
+    """
+    extract ASCII and UTF-16 LE strings from file
+    """
+    for s in capa.features.extractors.strings.extract_ascii_strings(buf):
+        yield String(s.s), s.offset
+
+    for s in capa.features.extractors.strings.extract_unicode_strings(buf):
+        yield String(s.s), s.offset
+
+
+def extract_file_features(buf, pe):
+    """
+    extract file features from given buffer and parsed binary
+
+    args:
+      buf (bytes): binary content
+      container (miasm.analysis.binary.ContainerPE): parsed binary returned by miasm
+
+    yields:
+      Tuple[Feature, VA]: a feature and its location.
+    """
+    for file_handler in FILE_HANDLERS:
+        for feature, va in file_handler(buf, pe):
+            yield feature, va
+
+
+FILE_HANDLERS = (
+    extract_file_embedded_pe,
+    extract_file_export_names,
+    extract_file_import_names,
+    extract_file_section_names,
+    extract_file_strings,
+)

--- a/capa/features/extractors/miasm/function.py
+++ b/capa/features/extractors/miasm/function.py
@@ -24,7 +24,9 @@ def extract_function_loop(extractor, loc_key):
     returns if the function has a loop
     """
     block = extractor.cfg.loc_key_to_block(loc_key)
-    disassembler = extractor.machine.dis_engine(extractor.container.bin_stream, follow_call=False)
+    disassembler = extractor.machine.dis_engine(
+        extractor.container.bin_stream, loc_db=extractor.loc_db, follow_call=False
+    )
     offset = extractor.block_offset(block)
     cfg = disassembler.dis_multiblock(offset)
     if cfg.has_loop():

--- a/capa/features/extractors/miasm/function.py
+++ b/capa/features/extractors/miasm/function.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2020 FireEye, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at: https://github.com/fireeye/capa/blob/master/LICENSE.txt
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+from capa.features import Characteristic
+
+
+def extract_function_calls_to(extractor, loc_key):
+    for pred_key in extractor.cfg.predecessors(loc_key):
+        pred_block = extractor.cfg.loc_key_to_block(pred_key)
+        pred_insn = pred_block.get_subcall_instr()
+        if pred_insn and pred_insn.is_subcall():
+            dst = pred_insn.args[0]
+            if dst.is_loc() and dst.loc_key == loc_key:
+                yield Characteristic("calls to"), pred_insn.offset
+
+
+def extract_function_loop(extractor, loc_key):
+    """
+    returns if the function has a loop
+    """
+    block = extractor.cfg.loc_key_to_block(loc_key)
+    disassembler = extractor.machine.dis_engine(extractor.container.bin_stream, follow_call=False)
+    offset = extractor.block_offset(block)
+    cfg = disassembler.dis_multiblock(offset)
+    if cfg.has_loop():
+        yield Characteristic("loop"), offset
+
+
+def extract_features(extractor, loc_key):
+    """
+    extract features from the given function.
+    args:
+      cfg (AsmCFG): the CFG of the function from which to extract features
+      loc_key (LocKey): LocKey which represents the beginning of the function
+    yields:
+      Feature, set[VA]: the features and their location found in this function.
+    """
+    for func_handler in FUNCTION_HANDLERS:
+        for feature, va in func_handler(extractor, loc_key):
+            yield feature, va
+
+
+FUNCTION_HANDLERS = (extract_function_calls_to, extract_function_loop)

--- a/capa/features/extractors/miasm/insn.py
+++ b/capa/features/extractors/miasm/insn.py
@@ -9,6 +9,7 @@
 import miasm.expression.expression
 
 import capa.features.extractors.helpers
+from capa.features.insn import Mnemonic
 
 
 # TODO: remove duplication (similar code in file.py)
@@ -64,7 +65,7 @@ def extract_insn_nzxor_characteristic_features(extractor, f, bb, insn):
 
 def extract_insn_mnemonic_features(extractor, f, bb, insn):
     """parse mnemonic features from the given instruction."""
-    raise NotImplementedError()
+    yield Mnemonic(insn.name), insn.offset
 
 
 def extract_insn_peb_access_characteristic_features(extractor, f, bb, insn):
@@ -115,7 +116,7 @@ INSTRUCTION_HANDLERS = (
     # extract_insn_bytes_features,
     # extract_insn_offset_features,
     # extract_insn_nzxor_characteristic_features,
-    # extract_insn_mnemonic_features,
+    extract_insn_mnemonic_features,
     # extract_insn_peb_access_characteristic_features,
     # extract_insn_cross_section_cflow,
     # extract_insn_segment_access_features,

--- a/capa/features/extractors/miasm/insn.py
+++ b/capa/features/extractors/miasm/insn.py
@@ -36,8 +36,9 @@ def extract_insn_api_features(extractor, _f, _bb, insn):
             target = int(arg.ptr)
             imports = get_imports(extractor.pe)
             if target in imports:
-                for feature, va in capa.features.extractors.helpers.generate_api_features(imports[target], insn.offset):
-                    yield feature, va
+                dll, _, symbol = imports[target].rpartition(".")
+                for feature in capa.features.extractors.helpers.generate_symbols(dll, symbol):
+                    yield feature, insn.offset
 
 
 def extract_insn_number_features(extractor, f, bb, insn):

--- a/capa/features/extractors/miasm/insn.py
+++ b/capa/features/extractors/miasm/insn.py
@@ -1,0 +1,97 @@
+# Copyright (C) 2020 FireEye, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at: https://github.com/fireeye/capa/blob/master/LICENSE.txt
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+
+def extract_insn_api_features(extractor, _, _, insn):
+    """parse API features from the given instruction."""
+    raise NotImplementedError()
+
+
+def extract_insn_number_features(extractor, f, bb, insn):
+    """parse number features from the given instruction."""
+    raise NotImplementedError()
+
+
+def extract_insn_string_features(extractor, f, bb, insn):
+    """parse string features from the given instruction."""
+    raise NotImplementedError()
+
+
+def extract_insn_offset_features(extractor, f, bb, insn):
+    """parse structure offset features from the given instruction."""
+    raise NotImplementedError()
+
+
+def extract_insn_nzxor_characteristic_features(extractor, f, bb, insn):
+    """
+    parse non-zeroing XOR instruction from the given instruction.
+    ignore expected non-zeroing XORs, e.g. security cookies.
+    """
+    raise NotImplementedError()
+
+
+def extract_insn_mnemonic_features(extractor, f, bb, insn):
+    """parse mnemonic features from the given instruction."""
+    raise NotImplementedError()
+
+
+def extract_insn_peb_access_characteristic_features(extractor, f, bb, insn):
+    """
+    parse peb access from the given function. fs:[0x30] on x86, gs:[0x60] on x64
+    """
+    raise NotImplementedError()
+
+
+def extract_insn_segment_access_features(extractor, f, bb, insn):
+    """ parse the instruction for access to fs or gs """
+    raise NotImplementedError()
+
+
+def extract_insn_cross_section_cflow(extractor, f, bb, insn):
+    """
+    inspect the instruction for a CALL or JMP that crosses section boundaries.
+    """
+    raise NotImplementedError()
+
+
+# this is a feature that's most relevant at the function scope,
+# however, its most efficient to extract at the instruction scope.
+def extract_function_calls_from(f, bb, insn):
+    raise NotImplementedError()
+
+
+def extract_features(extractor, f, bb, insn):
+    """
+    extract features from the given insn.
+    args:
+      extractor (MiasmFeatureExtractor)
+      f (miasm.expression.expression.LocKey): the function from which to extract features
+      bb (miasm.core.asmblock.AsmBlock): the basic block to process.
+      insn (Instruction): the instruction to process.
+    yields:
+      Feature, set[VA]: the features and their location found in this insn.
+    """
+    for insn_handler in INSTRUCTION_HANDLERS:
+        for feature, va in insn_handler(extractor, f, bb, insn):
+            yield feature, va
+
+
+INSTRUCTION_HANDLERS = (
+    # extract_insn_api_features,
+    # extract_insn_number_features,
+    # extract_insn_string_features,
+    # extract_insn_bytes_features,
+    # extract_insn_offset_features,
+    # extract_insn_nzxor_characteristic_features,
+    # extract_insn_mnemonic_features,
+    # extract_insn_peb_access_characteristic_features,
+    # extract_insn_cross_section_cflow,
+    # extract_insn_segment_access_features,
+    # extract_function_calls_from,
+    # extract_function_indirect_call_characteristic_features,
+)

--- a/capa/features/insn.py
+++ b/capa/features/insn.py
@@ -37,4 +37,4 @@ class Offset(Feature):
 
 class Mnemonic(Feature):
     def __init__(self, value, description=None):
-        super(Mnemonic, self).__init__(value, description=description)
+        super(Mnemonic, self).__init__(value.lower(), description=description)

--- a/capa/main.py
+++ b/capa/main.py
@@ -304,19 +304,27 @@ class UnsupportedRuntimeError(RuntimeError):
 
 
 def get_extractor_py3(path, format, disable_progress=False):
-    from smda.SmdaConfig import SmdaConfig
-    from smda.Disassembler import Disassembler
+    if False:  # TODO: How to decide which backend to use?
+        from smda.SmdaConfig import SmdaConfig
+        from smda.Disassembler import Disassembler
 
-    import capa.features.extractors.smda
+        import capa.features.extractors.smda
 
-    smda_report = None
-    with halo.Halo(text="analyzing program", spinner="simpleDots", stream=sys.stderr, enabled=not disable_progress):
-        config = SmdaConfig()
-        config.STORE_BUFFER = True
-        smda_disasm = Disassembler(config)
-        smda_report = smda_disasm.disassembleFile(path)
+        smda_report = None
+        with halo.Halo(text="analyzing program", spinner="simpleDots", stream=sys.stderr, enabled=not disable_progress):
+            config = SmdaConfig()
+            config.STORE_BUFFER = True
+            smda_disasm = Disassembler(config)
+            smda_report = smda_disasm.disassembleFile(path)
 
-    return capa.features.extractors.smda.SmdaFeatureExtractor(smda_report, path)
+        return capa.features.extractors.smda.SmdaFeatureExtractor(smda_report, path)
+    else:
+        import capa.features.extractors.miasm
+
+        with open(path, "rb") as f:
+            buf = f.read()
+
+        return capa.features.extractors.miasm.MiasmFeatureExtractor(buf)
 
 
 def get_extractor(path, format, disable_progress=False):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -242,14 +242,14 @@ def sample(request):
 
 def get_function(extractor, fva):
     for f in extractor.get_functions():
-        if f.__int__() == fva:
+        if extractor.function_offset(f) == fva:
             return f
     raise ValueError("function not found")
 
 
 def get_basic_block(extractor, f, va):
     for bb in extractor.get_basic_blocks(f):
-        if bb.__int__() == va:
+        if extractor.block_offset(bb) == va:
             return bb
     raise ValueError("basic block not found")
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -109,6 +109,17 @@ def get_smda_extractor(path):
 
 
 @lru_cache()
+def get_miasm_extractor(path):
+    import capa.features.extractors.miasm
+
+    with open(path, "rb") as f:
+        buf = f.read()
+
+    print("Using miasm!!!!")
+    return capa.features.extractors.miasm.MiasmFeatureExtractor(buf)
+
+
+@lru_cache()
 def extract_file_features(extractor):
     features = collections.defaultdict(set)
     for feature, va in extractor.extract_file_features():
@@ -521,7 +532,10 @@ def do_test_feature_count(get_extractor, sample, scope, feature, expected):
 
 def get_extractor(path):
     if sys.version_info >= (3, 0):
-        extractor = get_smda_extractor(path)
+        if False:  # TODO: How to decide which backend to use?
+            extractor = get_smda_extractor(path)
+        else:
+            extractor = get_miasm_extractor(path)
     else:
         extractor = get_viv_extractor(path)
 

--- a/tests/test_miasm_features.py
+++ b/tests/test_miasm_features.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2020 FireEye, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at: https://github.com/fireeye/capa/blob/master/LICENSE.txt
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+import sys
+
+from fixtures import *
+
+
+@parametrize(
+    "sample,scope,feature,expected",
+    FEATURE_PRESENCE_TESTS,
+    indirect=["sample", "scope"],
+)
+def test_miasm_features(sample, scope, feature, expected):
+    do_test_feature_presence(get_miasm_extractor, sample, scope, feature, expected)
+
+
+@parametrize(
+    "sample,scope,feature,expected",
+    FEATURE_COUNT_TESTS,
+    indirect=["sample", "scope"],
+)
+def test_miasm_feature_counts(sample, scope, feature, expected):
+    do_test_feature_count(get_miasm_extractor, sample, scope, feature, expected)


### PR DESCRIPTION
Add a backend to capa that's based on [miasm](https://github.com/cea-sec/miasm). It is at the moment a WIP. A finished implementation would add Python3 support and allow us to get rid of Python2 (making the development setup simpler and the code easier to mantain).

I think that how good the `get_functions` function works will determine how good the `miasm` backend works. So we will need to do some research there before we can merge this.

Apart from the `TODO`s in the code, the following is missing:

- Implementing some of the insn features
- Fix the `extract_stackstring` function in `basicblock.py` as it doesn't seem to work
- Fix the tests.  Some tests are failing due to the not yet implemented features. In addition, it looks like miasm has problems disassembling some of the used files. Apart from the ones in the tests, I noticed that miasm has problem disassembling `Lab15-01.exe` from PMA as well. One possible solution to avoid at least that capa fails is to check that the block is not of the class `miasm.core.asmblock.AsmBlockBad` (or use `cfg.get_bad_blocks()` to not even return them).

To ilustrate that the current extracted features work (with the exception of `extract_stackstring`) you can use the following dummy rules (they could be added to a test):

```
rule:
  meta:
    name: 'dummy file rule'
    namespace: test/dummy/file
    scope: file
  features:
    - and:
      - section: .text
      - characteristic: embedded pe
      - import: OpenProcessToken
      - export: InstallSA
      - string: /This is RNA/
      description: file features

rule:
  meta:
    name: 'dummy function rule'
    namespace: test/dummy/function
    scope: function
  features:
    - and:
      - count(characteristic(calls to)): 6
      - characteristic: loop
      description: function features

rule:
  meta:
    name: 'dummy basic block rule'
    namespace: test/dummy/bb
    scope: basic block
  features:
    - or:
      - characteristic: tight loop
      - characteristic: stack string
      description: basic block features

rule:
  meta:
    name: 'dummy insn rule'
    namespace: test/dummy/insn
    scope: function
  features:
    - and:
      - and:
        - count(mnemonic(xor)): 5
        - mnemonic: AND
        description: mnemonics
      - api: sprintf
      description: insn features
```

This produces the following output for PMA Lab17-02.dll with the `-vv` option:

```
dummy basic block rule
namespace  test/dummy/bb
scope      basic block
basic block @ 0x10014F7C
  or: = basic block features
    characteristic: tight loop @ 0x10014F7C

dummy file rule
namespace  test/dummy/file
scope      file
and: = file features
  section: .text @ 0x1000
  characteristic: embedded pe
  import: OpenProcessToken @ 0x10016004
  export: InstallSA @ 0x1000DEC1
  string: [This is RNA]newsnews @ 0x16AF4

dummy function rule
namespace  test/dummy/function
scope      function
function @ 0x10014F70
  and: = function features
    count(characteristic(calls to)): 6 @ 0x10005D92, 0x10006520, 0x10006654, 0x1000D930, and 2 more...
    characteristic: loop @ 0x10014F70

dummy insn rule
namespace  test/dummy/insn
scope      function
function @ 0x1000664C
  and: = insn features
    and: = mnemonics
      count(mnemonic(xor)): 5 @ 0x10006667, 0x10006676, 0x10006679, 0x1000683E, and 1 more...
      mnemonic: and @ 0x10006659
    api: sprintf @ 0x100066BF
```

I compare this with the IDA database and it looks accurate to me. The only remarkable thing I notice is that IDA find some more `calls_to`.

Related to https://github.com/fireeye/capa/issues/50