### PR TITLE
add additional nzxor stack cookie check for IDA extractor

### DIFF
--- a/capa/features/extractors/ida/__init__.py
+++ b/capa/features/extractors/ida/__init__.py
@@ -75,7 +75,7 @@ class IdaFeatureExtractor(FeatureExtractor):
             yield feature, ea
 
     def get_basic_blocks(self, f):
-        for bb in idaapi.FlowChart(f, flags=idaapi.FC_PREDS):
+        for bb in capa.features.extractors.ida.helpers.get_function_blocks(f):
             yield add_ea_int_cast(bb)
 
     def extract_basic_block_features(self, f, bb):

--- a/capa/features/extractors/ida/helpers.py
+++ b/capa/features/extractors/ida/helpers.py
@@ -341,3 +341,21 @@ def find_data_reference_from_insn(insn, max_depth=10):
         ea = data_refs[0]
 
     return ea
+
+
+def get_function_blocks(f):
+    """yield basic blocks contained in specified function
+
+    args:
+        f (IDA func_t)
+    yield:
+        block (IDA BasicBlock)
+    """
+    # leverage idaapi.FC_NOEXT flag to ignore useless external blocks referenced by the function
+    for block in idaapi.FlowChart(f, flags=(idaapi.FC_PREDS | idaapi.FC_NOEXT)):
+        yield block
+
+
+def is_basic_block_return(bb):
+    """ check if basic block is return block """
+    return bb.type == idaapi.fcb_ret


### PR DESCRIPTION
Fixes #237.

Adds additional `nzxor` stack cookie check for IDA extractor modeled after viv extractor. Previous code relied on IDA analysis to add stack/security-related comments to the corresponding instruction. IDA fails to do this for the function referenced in #237 so these checks fail.

`test_ida_features` now passing `nzxor` check IDA on 7.4/7.5 for Python 2/3 🚀:
```
...
OK   mimikatz-function=0x410DFC-characteristic(nzxor)-True
OK   mimikatz-function=0x40105D-characteristic(nzxor)-False
OK   mimikatz-function=0x46D534-characteristic(nzxor)-False
...
```