### PR TITLE
Fix 256: Pin enum34 version to 1.1.6 for python2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if sys.version_info >= (3, 0):
     requirements.append("networkx")
 else:
     # py2
-    requirements.append("enum34")
+    requirements.append("enum34==1.1.6")  # v1.1.6 is needed by halo 0.0.30 / spinners 0.0.24
     requirements.append("vivisect @ https://github.com/williballenthin/vivisect/tarball/v0.0.20200804#egg=vivisect")
     requirements.append("viv-utils")
     requirements.append("networkx==2.2")  # v2.2 is last version supported by Python 2.7


### PR DESCRIPTION
Fixes #256 - capa requires halo==0.0.30, which has a dependency on
spinners>=0.0.24. spinners 0.0.24 has a dependency on enum34==1.1.6,
but 1.1.10 gets installed and used on my machine without the version
being pinned to 1.1.6. This issue occurs when using python 2.7.