### PR TITLE
Set Tree View default expansion to 1 level

### DIFF
--- a/capa/ida/explorer/view.py
+++ b/capa/ida/explorer/view.py
@@ -59,12 +59,13 @@ class CapaExplorerQtreeView(QtWidgets.QTreeView):
         called when view should reset any user interface changes
         made since the last reset e.g. IDA window highlighting
         """
-        self.collapseAll()
+        self.expandToDepth(0)
         self.resize_columns_to_content()
 
     def resize_columns_to_content(self):
         """ reset view columns to contents """
         self.header().resizeSections(QtWidgets.QHeaderView.ResizeToContents)
+        self.expandToDepth(0)
 
     def map_index_to_source_item(self, model_index):
         """map proxy model index to source model item

--- a/capa/ida/explorer/view.py
+++ b/capa/ida/explorer/view.py
@@ -65,7 +65,6 @@ class CapaExplorerQtreeView(QtWidgets.QTreeView):
     def resize_columns_to_content(self):
         """ reset view columns to contents """
         self.header().resizeSections(QtWidgets.QHeaderView.ResizeToContents)
-        self.expandToDepth(0)
 
     def map_index_to_source_item(self, model_index):
         """map proxy model index to source model item

--- a/capa/ida/ida_capa_explorer.py
+++ b/capa/ida/ida_capa_explorer.py
@@ -529,7 +529,7 @@ class CapaExplorerForm(idaapi.PluginForm):
         else:
             self.model_proxy.reset_address_range_filter()
 
-        self.view_tree.resize_columns_to_content()
+        self.view_tree.reset()
 
     def limit_results_to_function(self, f):
         """add filter to limit results to current function


### PR DESCRIPTION
Rule information is collapsed by default and *Address* column is populated only at the first expansion layer.

There is no easy way to expand all results and *Address* column is very convenient to navigate to match locations. Setting expansion by default to 1 level so that match location addresses are shown to make navigation faster.