### PR TITLE
fix 263

### DIFF
--- a/capa/rules.py
+++ b/capa/rules.py
@@ -624,7 +624,19 @@ class Rule(object):
                 continue
             meta[key] = value
 
-        return ostream.getvalue().decode("utf-8").rstrip("\n") + "\n"
+        doc = ostream.getvalue().decode("utf-8").rstrip("\n") + "\n"
+        # when we have something like:
+        #
+        #     and:
+        #       - string: foo
+        #         description: bar
+        #
+        # we want the `description` horizontally aligned with the start of the `string`.
+        # tweaking `ruamel.indent()` doesn't quite give us the control we want.
+        # so, add the two extra spaces that we've determined we need through experimentation.
+        # see #263
+        doc = doc.replace("  description:", "    description:")
+        return doc
 
 
 def get_rules_with_scope(rules, scope):

--- a/capa/rules.py
+++ b/capa/rules.py
@@ -631,7 +631,13 @@ class Rule(object):
         #       - string: foo
         #         description: bar
         #
-        # we want the `description` horizontally aligned with the start of the `string`.
+        # we want the `description` horizontally aligned with the start of the `string` (like above).
+        # however, ruamel will give us (which I don't think is even valid yaml):
+        #
+        #     and:
+        #       - string: foo
+        #      description: bar
+        #
         # tweaking `ruamel.indent()` doesn't quite give us the control we want.
         # so, add the two extra spaces that we've determined we need through experimentation.
         # see #263

--- a/tests/test_fmt.py
+++ b/tests/test_fmt.py
@@ -92,6 +92,8 @@ def test_rule_reformat_order():
 
 
 def test_rule_reformat_meta_update():
+    # test updating the rule content after parsing
+
     rule = textwrap.dedent(
         """
         rule:
@@ -112,3 +114,23 @@ def test_rule_reformat_meta_update():
     rule = capa.rules.Rule.from_yaml(rule)
     rule.name = "test rule"
     assert rule.to_yaml() == EXPECTED
+
+
+def test_rule_reformat_string_description():
+    # see #263
+    src = textwrap.dedent(
+        """
+        rule:
+          meta:
+            name: test rule
+            author: user@domain.com
+            scope: function
+          features:
+            - and:
+              - string: foo
+                description: bar
+        """
+    )
+
+    rule = capa.rules.Rule.from_yaml(src)
+    assert rule.to_yaml() == src

--- a/tests/test_fmt.py
+++ b/tests/test_fmt.py
@@ -117,6 +117,7 @@ def test_rule_reformat_meta_update():
 
 
 def test_rule_reformat_string_description():
+    # the `description` should be aligned with the preceding feature name.
     # see #263
     src = textwrap.dedent(
         """
@@ -130,7 +131,7 @@ def test_rule_reformat_string_description():
               - string: foo
                 description: bar
         """
-    )
+    ).lstrip()
 
     rule = capa.rules.Rule.from_yaml(src)
     assert rule.to_yaml() == src


### PR DESCRIPTION
when reformatting a rule that has a description in two-line style (like for a `string`), then ensure the description is aligned horizontally.

i don't love the manual override of ruamel here, but its much easier than trying to figure out how its parser and emitter actually work. tried a couple of settings (see `ruamel.yaml.indent()`) but couldn't get it working without this override.

closes #263 (capafmt emits invalid rules)

cc: @recvfrom