### PR TITLE
ida plugin: don't use rule path settings if the path doesn't exist

### DIFF
--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -333,7 +333,7 @@ class CapaExplorerForm(idaapi.PluginForm):
 
         # resolve rules directory - check self and settings first, then ask user
         if not self.rule_path:
-            if "rule_path" in settings:
+            if "rule_path" in settings and os.path.exists(settings["rule_path"]):
                 self.rule_path = settings["rule_path"]
             else:
                 rule_path = self.ask_user_directory()


### PR DESCRIPTION
if the rule path that was saved via settings doesn't exist, re-prompt the user for their rules path.

closes #298