### PR TITLE
ida plugin: ui improvements

### DIFF
--- a/capa/ida/plugin/__init__.py
+++ b/capa/ida/plugin/__init__.py
@@ -41,25 +41,20 @@ class CapaExplorerPlugin(idaapi.plugin_t):
         """called when IDA is loading the plugin"""
         logging.basicConfig(level=logging.INFO)
 
-        # check IDA version and database compatibility
+        # do not load plugin if IDA version/file type not supported
         if not is_supported_ida_version():
             return idaapi.PLUGIN_SKIP
         if not is_supported_file_type():
             return idaapi.PLUGIN_SKIP
-
-        logger.debug("plugin initialized")
-
-        # plugin is good, but don't keep us in memory
         return idaapi.PLUGIN_OK
 
     def term(self):
         """called when IDA is unloading the plugin"""
-        logger.debug("plugin terminated")
+        pass
 
     def run(self, arg):
         """called when IDA is running the plugin as a script"""
         self.form = CapaExplorerForm(self.PLUGIN_NAME)
-        self.form.Show()
         return True
 
 

--- a/capa/ida/plugin/model.py
+++ b/capa/ida/plugin/model.py
@@ -29,7 +29,7 @@ from capa.ida.plugin.item import (
 )
 
 # default highlight color used in IDA window
-DEFAULT_HIGHLIGHT = 0xD096FF
+DEFAULT_HIGHLIGHT = 0xE6C700
 
 
 class CapaExplorerDataModel(QtCore.QAbstractItemModel):
@@ -144,7 +144,7 @@ class CapaExplorerDataModel(QtCore.QAbstractItemModel):
 
         if role == QtCore.Qt.ForegroundRole and column == CapaExplorerDataModel.COLUMN_INDEX_VIRTUAL_ADDRESS:
             # set color for virtual address column
-            return QtGui.QColor(88, 139, 174)
+            return QtGui.QColor(37, 147, 215)
 
         if (
             role == QtCore.Qt.ForegroundRole


### PR DESCRIPTION
Brings new improvements to IDA plugin:

improvements:

* new `Analyze` and `Reset` buttons added to UI - quick access to run analysis and reset plugin and IDA user interfaces
   * removes `Rerun analysis` and `View` options from menu bar
* plugin does not run database analysis automatically when started - better matches life cycle of a plugin versus script
  * users must explicitily run database analysis using `Analyze` button
* font color of `Address` column and IDA highlight color updated to match capa logo
* UI controls disabled until analysis has been performed
* additional messages added to status label - help guide users when interacting with plugin
* remove unnecessary debug printing
* remove unused code