### PR TITLE
set level of more viv loggers explicitly

### DIFF
--- a/capa/main.py
+++ b/capa/main.py
@@ -40,8 +40,11 @@ logger = logging.getLogger("capa")
 
 def set_vivisect_log_level(level):
     logging.getLogger("vivisect").setLevel(level)
+    logging.getLogger("vivisect.base").setLevel(level)
+    logging.getLogger("vivisect.impemu").setLevel(level)
     logging.getLogger("vtrace").setLevel(level)
     logging.getLogger("envi").setLevel(level)
+    logging.getLogger("envi.codeflow").setLevel(level)
 
 
 def find_function_capabilities(ruleset, extractor, f):


### PR DESCRIPTION
TODO it still may show the below in some instances; haven't been able to disable this yet

`WARNING:envi:i386RegOper needs to implement getOperAddr!`

For example on `3b13b6f1d7cd14dc4a097a12e2e505c0a4cff495262261e2bfc991df238b9b04.dll_`
```
$ capa 3b13b6f1d7cd14dc4a097a12e2e505c0a4cff495262261e2bfc991df238b9b04 .dll_
loading : 100%|████████████████████████████████████████████████████████████████████████████████████████████| 433/433 [00:01<00:00, 324.81     rules/s]
... analyzing programWARNING:envi:i386RegOper needs to implement getOperAddr!
WARNING:envi:i386RegOper needs to implement getOperAddr!
```