### PR TITLE
fix AttributeError: 'str' object has no attribute 'name'

### DIFF
--- a/capa/features/extractors/smda/file.py
+++ b/capa/features/extractors/smda/file.py
@@ -67,7 +67,8 @@ def extract_file_export_names(smda_report, file_path):
     lief_binary = lief.parse(file_path)
     if lief_binary is not None:
         for function in lief_binary.exported_functions:
-            yield Export(function.name), function.address
+            if function and not isinstance(function, str):
+                yield Export(function.name), function.address
 
 
 def extract_file_import_names(smda_report, file_path):


### PR DESCRIPTION
before
```
capa -r /opt/CAPEv2/data/capa-rules/ procdump/25cd534d2b91cacad8949d9b67ffea454f1bd430a68d963423fa10c62c358c9c

Traceback (most recent call last):
  File "/usr/local/bin/capa", line 33, in <module>
    sys.exit(load_entry_point('flare-capa==1.4.0', 'console_scripts', 'capa')())
  File "/usr/local/lib/python3.6/dist-packages/capa/main.py", line 617, in main
    capabilities, counts = find_capabilities(rules, extractor, disable_progress=args.quiet)
  File "/usr/local/lib/python3.6/dist-packages/capa/main.py", line 132, in find_capabilities
    all_file_matches, feature_count = find_file_capabilities(ruleset, extractor, function_features)
  File "/usr/local/lib/python3.6/dist-packages/capa/main.py", line 86, in find_file_capabilities
    for feature, va in extractor.extract_file_features():
  File "/usr/local/lib/python3.6/dist-packages/capa/features/extractors/smda/__init__.py", line 27, in extract_file_features
    for feature, va in capa.features.extractors.smda.file.extract_features(self.smda_report, self.path):
  File "/usr/local/lib/python3.6/dist-packages/capa/features/extractors/smda/file.py", line 129, in extract_features
    for feature, va in file_handler(smda_report, file_path):
  File "/usr/local/lib/python3.6/dist-packages/capa/features/extractors/smda/file.py", line 70, in extract_file_export_names
    yield Export(function.name), function.address
AttributeError: 'str' object has no attribute 'name'
```

after
```
/opt/CAPEv2/storage/analyses/107382$ capa -r /opt/CAPEv2/data/capa-rules/ procdump/25cd534d2b91cacad8949d9b67ffea454f1bd430a68d963423fa10c62c358c9c

+------------------------+------------------------------------------------------------------------------------+
| md5                    | 0a47006f37005dc6492f359cfb5a86c2                                                   |
| sha1                   | fb04b0a04a94933d288f7a694d5eeee29cad16a1                                           |
| sha256                 | 25cd534d2b91cacad8949d9b67ffea454f1bd430a68d963423fa10c62c358c9c                   |
| path                   | procdump/25cd534d2b91cacad8949d9b67ffea454f1bd430a68d963423fa10c62c358c9c          |
+------------------------+------------------------------------------------------------------------------------+

+------------------------+------------------------------------------------------------------------------------+
| ATT&CK Tactic          | ATT&CK Technique                                                                   |
|------------------------+------------------------------------------------------------------------------------|
| DISCOVERY              | System Information Discovery [T1082]                                               |
|                        | System Owner/User Discovery [T1033]                                                |
| EXECUTION              | Shared Modules [T1129]                                                             |
+------------------------+------------------------------------------------------------------------------------+

+-----------------------------+-------------------------------------------------------------------------------+
| MBC Objective               | MBC Behavior                                                                  |
|-----------------------------+-------------------------------------------------------------------------------|
| ANTI-BEHAVIORAL ANALYSIS    | Debugger Detection::Software Breakpoints [B0001.025]                          |
+-----------------------------+-------------------------------------------------------------------------------+

+------------------------------------------------------+------------------------------------------------------+
| CAPABILITY                                           | NAMESPACE                                            |
|------------------------------------------------------+------------------------------------------------------|
| check for software breakpoints                       | anti-analysis/anti-debugging/debugger-detection      |
| connect network resource (2 matches)                 | communication/http                                   |
| contain a resource (.rsrc) section                   | executable/pe/section/rsrc                           |
| extract resource via kernel32 functions (4 matches)  | executable/resource                                  |
| manipulate console (2 matches)                       | host-interaction/console                             |
| write file (2 matches)                               | host-interaction/file-system/write                   |
| get hostname (2 matches)                             | host-interaction/os/hostname                         |
| terminate process                                    | host-interaction/process/terminate                   |
| set registry value                                   | host-interaction/registry/create                     |
| delete registry key                                  | host-interaction/registry/delete                     |
| open registry key (2 matches)                        | host-interaction/registry/open                       |
| get token membership                                 | host-interaction/session                             |
| link function at runtime (2 matches)                 | linking/runtime-linking                              |
| parse PE header (3 matches)                          | load-code/pe                                         |
+------------------------------------------------------+------------------------------------------------------+
```


procdump can be downloaded from here https://capesandbox.com/analysis/107382/