### PR TITLE
Lint rule formatting and improved rule dump

### DIFF
--- a/capa/rules.py
+++ b/capa/rules.py
@@ -6,6 +6,7 @@
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+import re
 import uuid
 import codecs
 import logging
@@ -727,6 +728,14 @@ class Rule(object):
         # assumes features section always exists
         features_offset = doc.find("features")
         doc = doc[:features_offset] + doc[features_offset:].replace("  description:", "    description:")
+
+        # for negative hex numbers, yaml dump outputs:
+        # - offset: !!int '0x-30'
+        # we prefer:
+        # - offset: -0x30
+        # the below regex makes these adjustments and while ugly, we don't have to explore the ruamel.yaml insides
+        doc = re.sub(r"!!int '0x-([0-9a-fA-F]+)'", r"-0x\1", doc)
+
         return doc
 
 

--- a/capa/rules.py
+++ b/capa/rules.py
@@ -600,6 +600,9 @@ class Rule(object):
         # use block mode, not inline json-like mode
         y.default_flow_style = False
 
+        # leave quotes unchanged
+        y.preserve_quotes = True
+
         # indent lists by two spaces below their parent
         #
         #     features:

--- a/scripts/capafmt.py
+++ b/scripts/capafmt.py
@@ -14,7 +14,6 @@ Unless required by applicable law or agreed to in writing, software distributed 
  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
 """
-import re
 import sys
 import logging
 import argparse
@@ -59,9 +58,6 @@ def main(argv=None):
 
     rule = capa.rules.Rule.from_yaml_file(args.path, use_ruamel=True)
     reformatted_rule = rule.to_yaml()
-
-    # fix negative numbers
-    reformatted_rule = re.sub(r"!!int '0x-([0-9a-fA-F]+)'", r"-0x\1", reformatted_rule)
 
     if args.check:
         if rule.definition == reformatted_rule:

--- a/scripts/capafmt.py
+++ b/scripts/capafmt.py
@@ -14,6 +14,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
 """
+import re
 import sys
 import logging
 import argparse
@@ -59,6 +60,9 @@ def main(argv=None):
     rule = capa.rules.Rule.from_yaml_file(args.path, use_ruamel=True)
     reformatted_rule = rule.to_yaml()
 
+    # fix negative numbers
+    reformatted_rule = re.sub(r"!!int '0x-([0-9a-fA-F]+)'", r"-0x\1", reformatted_rule)
+
     if args.check:
         if rule.definition == reformatted_rule:
             logger.info("rule is formatted correctly, nice! (%s)", rule.name)
@@ -71,7 +75,7 @@ def main(argv=None):
         with open(args.path, "wb") as f:
             f.write(reformatted_rule.encode("utf-8"))
     else:
-        print(rule.to_yaml().rstrip("\n"))
+        print(reformatted_rule)
 
     return 0
 

--- a/scripts/capafmt.py
+++ b/scripts/capafmt.py
@@ -50,7 +50,7 @@ def main(argv=None):
     logging.basicConfig(level=level)
     logging.getLogger("capafmt").setLevel(level)
 
-    rule = capa.rules.Rule.from_yaml_file(args.path)
+    rule = capa.rules.Rule.from_yaml_file(args.path, use_ruamel=True)
     if args.in_place:
         with open(args.path, "wb") as f:
             f.write(rule.to_yaml().encode("utf-8"))

--- a/scripts/capafmt.py
+++ b/scripts/capafmt.py
@@ -38,6 +38,12 @@ def main(argv=None):
     )
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable debug logging")
     parser.add_argument("-q", "--quiet", action="store_true", help="Disable all output but errors")
+    parser.add_argument(
+        "-c",
+        "--check",
+        action="store_true",
+        help="Don't output (reformatted) rule, only return status. 0 = no changes, 1 = would reformat",
+    )
     args = parser.parse_args(args=argv)
 
     if args.verbose:
@@ -51,9 +57,19 @@ def main(argv=None):
     logging.getLogger("capafmt").setLevel(level)
 
     rule = capa.rules.Rule.from_yaml_file(args.path, use_ruamel=True)
+    reformatted_rule = rule.to_yaml()
+
+    if args.check:
+        if rule.definition == reformatted_rule:
+            logger.info("rule is formatted correctly, nice! (%s)", rule.name)
+            return 0
+        else:
+            logger.info("rule requires reformatting (%s)", rule.name)
+            return 1
+
     if args.in_place:
         with open(args.path, "wb") as f:
-            f.write(rule.to_yaml().encode("utf-8"))
+            f.write(reformatted_rule.encode("utf-8"))
     else:
         print(rule.to_yaml().rstrip("\n"))
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -557,6 +557,7 @@ def main(argv=None):
 
     capa.main.set_vivisect_log_level(logging.CRITICAL)
     logging.getLogger("capa").setLevel(logging.CRITICAL)
+    logging.getLogger("viv_utils").setLevel(logging.CRITICAL)
 
     time0 = time.time()
 
@@ -588,8 +589,8 @@ def main(argv=None):
 
     did_violate = lint(ctx, rules)
 
-    diff = time.time() - time0
-    logger.debug("lint ran for ~ %02d:%02d", (diff // 60), diff)
+    min, sec = divmod(time.time() - time0, 60)
+    logger.debug("lints ran for ~ %02d:%02dm", min, sec)
 
     if not did_violate:
         logger.info("no suggestions, nice!")

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -14,7 +14,6 @@ Unless required by applicable law or agreed to in writing, software distributed 
 See the License for the specific language governing permissions and limitations under the License.
 """
 import os
-import re
 import sys
 import time
 import string
@@ -297,12 +296,6 @@ class FormatIncorrect(Lint):
     def check_rule(self, ctx, rule):
         actual = rule.definition
         expected = capa.rules.Rule.from_yaml(rule.definition, use_ruamel=True).to_yaml()
-
-        # fix negative numbers
-        # - offset: -0x30
-        # instead of
-        # - offset: !!int '0x-30'
-        expected = re.sub(r"!!int '0x-([0-9a-fA-F]+)'", r"-0x\1", expected)
 
         if actual != expected:
             diff = difflib.ndiff(actual.splitlines(1), expected.splitlines(1))

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -14,6 +14,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 See the License for the specific language governing permissions and limitations under the License.
 """
 import os
+import re
 import sys
 import time
 import string
@@ -297,9 +298,11 @@ class FormatIncorrect(Lint):
         actual = rule.definition
         expected = capa.rules.Rule.from_yaml(rule.definition, use_ruamel=True).to_yaml()
 
-        # ignore different quote characters
-        actual = actual.replace("'", '"')
-        expected = expected.replace("'", '"')
+        # fix negative numbers
+        # - offset: -0x30
+        # instead of
+        # - offset: !!int '0x-30'
+        expected = re.sub(r"!!int '0x-([0-9a-fA-F]+)'", r"-0x\1", expected)
 
         if actual != expected:
             diff = difflib.ndiff(actual.splitlines(1), expected.splitlines(1))

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -301,10 +301,8 @@ class FormatIncorrect(Lint):
         actual = actual.replace("'", '"')
         expected = expected.replace("'", '"')
 
-        diff = list(difflib.ndiff(actual.splitlines(1), expected.splitlines(1)))
-        # deltas begin with two-letter code; "  " means common line
-        difflen = len(list(filter(lambda l: not l.startswith("  "), diff)))
-        if difflen > 0:
+        if actual != expected:
+            diff = difflib.ndiff(actual.splitlines(1), expected.splitlines(1))
             self.recommendation = self.recommendation_template.format("".join(diff))
             return True
 


### PR DESCRIPTION
- changes to arrive at the desired yaml rule format
- capafmt option to only check differences
- linter updates to ensure right yaml formatting

The changes in https://github.com/fireeye/capa-rules/pull/230 have been performed using the updated `capafmt` script included here.

closes #313