### PR TITLE
adjust expected lib path and log time

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and limitations 
 """
 import os
 import sys
+import time
 import string
 import hashlib
 import logging
@@ -226,14 +227,13 @@ class LibRuleNotInLibDirectory(Lint):
     recommendation = "Move the rule to the `lib` subdirectory of the rules path"
 
     def check_rule(self, ctx, rule):
-        logger.debug(rule.meta)
         if is_nursery_rule(rule):
             return False
 
         if "lib" not in rule.meta:
             return False
 
-        return "/lib/" not in get_normpath(rule.meta["capa/path"])
+        return "lib/" not in get_normpath(rule.meta["capa/path"])
 
 
 class LibRuleHasNamespace(Lint):
@@ -519,8 +519,10 @@ def main(argv=None):
     capa.main.set_vivisect_log_level(logging.CRITICAL)
     logging.getLogger("capa").setLevel(logging.CRITICAL)
 
+    time0 = time.time()
+
     try:
-        rules = capa.main.get_rules(args.rules)
+        rules = capa.main.get_rules(args.rules, disable_progress=True)
         rules = capa.rules.RuleSet(rules)
         logger.info("successfully loaded %s rules", len(rules))
         if args.tag:
@@ -546,6 +548,10 @@ def main(argv=None):
     }
 
     did_violate = lint(ctx, rules)
+
+    diff = time.time() - time0
+    logger.debug("lint ran for ~ %02d:%02d", (diff // 60), diff)
+
     if not did_violate:
         logger.info("no suggestions, nice!")
         return 0


### PR DESCRIPTION
expected lib path created issues when running the linter in the current directory `.`