### PR TITLE
Python3 support for vivisect

### DIFF
--- a/capa/features/extractors/viv/__init__.py
+++ b/capa/features/extractors/viv/__init__.py
@@ -8,11 +8,7 @@
 
 import types
 
-import file
-import insn
-import function
 import viv_utils
-import basicblock
 
 import capa.features.extractors
 import capa.features.extractors.viv.file
@@ -42,7 +38,7 @@ def add_va_int_cast(o):
     this bit of skullduggery lets use cast viv-utils objects as ints.
     the correct way of doing this is to update viv-utils (or subclass the objects here).
     """
-    setattr(o, "__int__", types.MethodType(get_va, o, type(o)))
+    setattr(o, "__int__", types.MethodType(get_va, o))
     return o
 
 

--- a/capa/features/extractors/viv/basicblock.py
+++ b/capa/features/extractors/viv/basicblock.py
@@ -125,11 +125,16 @@ def get_printable_len(oper):
 
 
 def is_printable_ascii(chars):
-    return all(ord(c) < 127 and c in string.printable for c in chars)
+    try:
+        chars_str = chars.decode("ascii")
+    except UnicodeDecodeError:
+        return False
+    else:
+        return all(c in string.printable for c in chars_str)
 
 
 def is_printable_utf16le(chars):
-    if all(c == "\x00" for c in chars[1::2]):
+    if all(c == b"\x00" for c in chars[1::2]):
         return is_printable_ascii(chars[::2])
 
 

--- a/capa/features/extractors/viv/insn.py
+++ b/capa/features/extractors/viv/insn.py
@@ -239,7 +239,7 @@ def read_bytes(vw, va):
     """
     segm = vw.getSegment(va)
     if not segm:
-        raise envi.SegmentationViolation()
+        raise envi.SegmentationViolation(va)
 
     segm_end = segm[0] + segm[1]
     try:

--- a/capa/features/extractors/viv/insn.py
+++ b/capa/features/extractors/viv/insn.py
@@ -488,7 +488,7 @@ def extract_insn_segment_access_features(f, bb, insn):
 
 def get_section(vw, va):
     for start, length, _, __ in vw.getMemoryMaps():
-        if va and start <= va < start + length:
+        if start <= va < start + length:
             return start
 
     raise KeyError(va)

--- a/capa/features/extractors/viv/insn.py
+++ b/capa/features/extractors/viv/insn.py
@@ -488,7 +488,7 @@ def extract_insn_segment_access_features(f, bb, insn):
 
 def get_section(vw, va):
     for start, length, _, __ in vw.getMemoryMaps():
-        if start <= va < start + length:
+        if va and start <= va < start + length:
             return start
 
     raise KeyError(va)

--- a/capa/features/freeze.py
+++ b/capa/features/freeze.py
@@ -264,14 +264,15 @@ def main(argv=None):
     parser.add_argument(
         "-f", "--format", choices=[f[0] for f in formats], default="auto", help="Select sample format, %s" % format_help
     )
-    parser.add_argument(
-        "-b",
-        "--backend",
-        type=str,
-        help="select the backend to use in Python 3 (this option is ignored in Python 2)",
-        choices=(capa.main.BACKEND_VIV, capa.main.BACKEND_SMDA),
-        default=capa.main.BACKEND_VIV,
-    )
+    if sys.version_info >= (3, 0):
+        parser.add_argument(
+            "-b",
+            "--backend",
+            type=str,
+            help="select the backend to use",
+            choices=(capa.main.BACKEND_VIV, capa.main.BACKEND_SMDA),
+            default=capa.main.BACKEND_VIV,
+        )
     args = parser.parse_args(args=argv)
 
     if args.quiet:
@@ -284,7 +285,8 @@ def main(argv=None):
         logging.basicConfig(level=logging.INFO)
         logging.getLogger().setLevel(logging.INFO)
 
-    extractor = capa.main.get_extractor(args.sample, args.format, args.backend)
+    backend = args.backend if sys.version_info > (3, 0) else None
+    extractor = capa.main.get_extractor(args.sample, args.format, backend)
     with open(args.output, "wb") as f:
         f.write(dump(extractor))
 

--- a/capa/features/freeze.py
+++ b/capa/features/freeze.py
@@ -285,7 +285,7 @@ def main(argv=None):
         logging.basicConfig(level=logging.INFO)
         logging.getLogger().setLevel(logging.INFO)
 
-    backend = args.backend if sys.version_info > (3, 0) else None
+    backend = args.backend if sys.version_info > (3, 0) else capa.main.BACKEND_VIV
     extractor = capa.main.get_extractor(args.sample, args.format, backend)
     with open(args.output, "wb") as f:
         f.write(dump(extractor))

--- a/capa/features/freeze.py
+++ b/capa/features/freeze.py
@@ -264,6 +264,14 @@ def main(argv=None):
     parser.add_argument(
         "-f", "--format", choices=[f[0] for f in formats], default="auto", help="Select sample format, %s" % format_help
     )
+    parser.add_argument(
+        "-b",
+        "--backend",
+        type=str,
+        help="select the backend to use in Python 3 (this option is ignored in Python 2)",
+        choices=(capa.main.BACKEND_VIV, capa.main.BACKEND_SMDA),
+        default=capa.main.BACKEND_VIV,
+    )
     args = parser.parse_args(args=argv)
 
     if args.quiet:
@@ -276,7 +284,7 @@ def main(argv=None):
         logging.basicConfig(level=logging.INFO)
         logging.getLogger().setLevel(logging.INFO)
 
-    extractor = capa.main.get_extractor(args.sample, args.format)
+    extractor = capa.main.get_extractor(args.sample, args.format, args.backend)
     with open(args.output, "wb") as f:
         f.write(dump(extractor))
 

--- a/capa/main.py
+++ b/capa/main.py
@@ -303,8 +303,8 @@ class UnsupportedRuntimeError(RuntimeError):
     pass
 
 
-def get_extractor_py3(path, format, disable_progress=False):
-    if False:
+def get_extractor_py3(path, format, backend, disable_progress=False):
+    if backend == "smda":
         from smda.SmdaConfig import SmdaConfig
         from smda.Disassembler import Disassembler
 
@@ -333,13 +333,13 @@ def get_extractor_py3(path, format, disable_progress=False):
         return capa.features.extractors.viv.VivisectFeatureExtractor(vw, path)
 
 
-def get_extractor(path, format, disable_progress=False):
+def get_extractor(path, format, backend="vivisect", disable_progress=False):
     """
     raises:
       UnsupportedFormatError:
     """
     if sys.version_info >= (3, 0):
-        return get_extractor_py3(path, format, disable_progress=disable_progress)
+        return get_extractor_py3(path, format, backend, disable_progress=disable_progress)
     else:
         return get_extractor_py2(path, format, disable_progress=disable_progress)
 
@@ -515,6 +515,14 @@ def main(argv=None):
     parser.add_argument(
         "-f", "--format", choices=[f[0] for f in formats], default="auto", help="select sample format, %s" % format_help
     )
+    parser.add_argument(
+        "-b",
+        "--backend",
+        type=str,
+        help="select the backend to use in Python 3 (this option is ignored in Python 2)",
+        choices=("vivisect", "smda"),
+        default="vivisect",
+    )
     parser.add_argument("-t", "--tag", type=str, help="filter on rule meta field values")
     parser.add_argument("-j", "--json", action="store_true", help="emit JSON instead of text")
     parser.add_argument(
@@ -619,7 +627,7 @@ def main(argv=None):
     else:
         format = args.format
         try:
-            extractor = get_extractor(args.sample, args.format, disable_progress=args.quiet)
+            extractor = get_extractor(args.sample, args.format, args.backend, disable_progress=args.quiet)
         except UnsupportedFormatError:
             logger.error("-" * 80)
             logger.error(" Input file does not appear to be a PE file.")

--- a/capa/main.py
+++ b/capa/main.py
@@ -630,7 +630,7 @@ def main(argv=None):
     else:
         format = args.format
         try:
-            backend = args.backend if sys.version_info > (3, 0) else None
+            backend = args.backend if sys.version_info > (3, 0) else capa.main.BACKEND_VIV
             extractor = get_extractor(args.sample, args.format, backend, disable_progress=args.quiet)
         except UnsupportedFormatError:
             logger.error("-" * 80)

--- a/capa/main.py
+++ b/capa/main.py
@@ -33,6 +33,8 @@ from capa.helpers import oint, get_file_taste
 
 RULES_PATH_DEFAULT_STRING = "(embedded rules)"
 SUPPORTED_FILE_MAGIC = set([b"MZ"])
+BACKEND_VIV = "vivisect"
+BACKEND_SMDA = "smda"
 
 
 logger = logging.getLogger("capa")
@@ -333,7 +335,7 @@ def get_extractor_py3(path, format, backend, disable_progress=False):
         return capa.features.extractors.viv.VivisectFeatureExtractor(vw, path)
 
 
-def get_extractor(path, format, backend="vivisect", disable_progress=False):
+def get_extractor(path, format, backend=BACKEND_VIV, disable_progress=False):
     """
     raises:
       UnsupportedFormatError:
@@ -520,8 +522,8 @@ def main(argv=None):
         "--backend",
         type=str,
         help="select the backend to use in Python 3 (this option is ignored in Python 2)",
-        choices=("vivisect", "smda"),
-        default="vivisect",
+        choices=(BACKEND_VIV, BACKEND_SMDA),
+        default=BACKEND_VIV,
     )
     parser.add_argument("-t", "--tag", type=str, help="filter on rule meta field values")
     parser.add_argument("-j", "--json", action="store_true", help="emit JSON instead of text")

--- a/capa/main.py
+++ b/capa/main.py
@@ -335,7 +335,7 @@ def get_extractor_py3(path, format, backend, disable_progress=False):
         return capa.features.extractors.viv.VivisectFeatureExtractor(vw, path)
 
 
-def get_extractor(path, format, backend=BACKEND_VIV, disable_progress=False):
+def get_extractor(path, format, backend, disable_progress=False):
     """
     raises:
       UnsupportedFormatError:

--- a/capa/main.py
+++ b/capa/main.py
@@ -517,14 +517,15 @@ def main(argv=None):
     parser.add_argument(
         "-f", "--format", choices=[f[0] for f in formats], default="auto", help="select sample format, %s" % format_help
     )
-    parser.add_argument(
-        "-b",
-        "--backend",
-        type=str,
-        help="select the backend to use in Python 3 (this option is ignored in Python 2)",
-        choices=(BACKEND_VIV, BACKEND_SMDA),
-        default=BACKEND_VIV,
-    )
+    if sys.version_info >= (3, 0):
+        parser.add_argument(
+            "-b",
+            "--backend",
+            type=str,
+            help="select the backend to use",
+            choices=(BACKEND_VIV, BACKEND_SMDA),
+            default=BACKEND_VIV,
+        )
     parser.add_argument("-t", "--tag", type=str, help="filter on rule meta field values")
     parser.add_argument("-j", "--json", action="store_true", help="emit JSON instead of text")
     parser.add_argument(
@@ -629,7 +630,8 @@ def main(argv=None):
     else:
         format = args.format
         try:
-            extractor = get_extractor(args.sample, args.format, args.backend, disable_progress=args.quiet)
+            backend = args.backend if sys.version_info > (3, 0) else None
+            extractor = get_extractor(args.sample, args.format, backend, disable_progress=args.quiet)
         except UnsupportedFormatError:
             logger.error("-" * 80)
             logger.error(" Input file does not appear to be a PE file.")

--- a/scripts/bulk-process.py
+++ b/scripts/bulk-process.py
@@ -95,7 +95,7 @@ def get_capa_results(args):
     rules, format, path = args
     logger.info("computing capa results for: %s", path)
     try:
-        extractor = capa.main.get_extractor(path, format, disable_progress=True)
+        extractor = capa.main.get_extractor(path, format, capa.main.BACKEND_VIV, disable_progress=True)
     except capa.main.UnsupportedFormatError:
         # i'm 100% sure if multiprocessing will reliably raise exceptions across process boundaries.
         # so instead, return an object with explicit success/failure status.

--- a/scripts/capa_as_library.py
+++ b/scripts/capa_as_library.py
@@ -191,7 +191,7 @@ def render_dictionary(doc):
 def capa_details(file_path, output_format="dictionary"):
 
     # extract features and find capabilities
-    extractor = capa.main.get_extractor(file_path, "auto", disable_progress=True)
+    extractor = capa.main.get_extractor(file_path, "auto", capa.main.BACKEND_VIV, disable_progress=True)
     capabilities, counts = capa.main.find_capabilities(rules, extractor, disable_progress=True)
 
     # collect metadata (used only to make rendering more complete)

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -201,7 +201,7 @@ class DoesntMatchExample(Lint):
                 continue
 
             try:
-                extractor = capa.main.get_extractor(path, "auto", disable_progress=True)
+                extractor = capa.main.get_extractor(path, "auto", capa.main.BACKEND_VIV, disable_progress=True)
                 capabilities, meta = capa.main.find_capabilities(ctx["rules"], extractor, disable_progress=True)
             except Exception as e:
                 logger.error("failed to extract capabilities: %s %s %s", rule.name, path, e)

--- a/scripts/show-capabilities-by-function.py
+++ b/scripts/show-capabilities-by-function.py
@@ -199,7 +199,7 @@ def main(argv=None):
         else:
             format = args.format
             try:
-                extractor = capa.main.get_extractor(args.sample, args.format)
+                extractor = capa.main.get_extractor(args.sample, args.format, capa.main.BACKEND_VIV)
             except capa.main.UnsupportedFormatError:
                 logger.error("-" * 80)
                 logger.error(" Input file does not appear to be a PE file.")

--- a/scripts/show-features.py
+++ b/scripts/show-features.py
@@ -125,7 +125,7 @@ def main(argv=None):
             extractor = capa.features.freeze.load(f.read())
     else:
         try:
-            extractor = capa.main.get_extractor(args.sample, args.format)
+            extractor = capa.main.get_extractor(args.sample, args.format, capa.main.BACKEND_VIV)
         except capa.main.UnsupportedFormatError:
             logger.error("-" * 80)
             logger.error(" Input file does not appear to be a PE file.")

--- a/scripts/vivisect-py2-vs-py3.sh
+++ b/scripts/vivisect-py2-vs-py3.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+int() {
+  int=$(bc <<< "scale=0; ($1 + 0.5)/1")
+}
+
+export TIMEFORMAT='%3R'
+threshold_time=90
+threshold_py3_time=60 # Do not warn if it doesn't take at least 1 minute to run
+rm tests/data/*.viv 2>/dev/null
+mkdir results
+for file in tests/data/*
+do
+  file=$(printf %q "$file") # Handle names with white spaces
+  file_name=$(basename $file)
+  echo $file_name
+
+  rm "$file.viv" 2>/dev/null
+  py3_time=$(sh -c "time python3 scripts/show-features.py $file >> results/p3-$file_name.out 2>/dev/null" 2>&1)
+  rm "$file.viv" 2>/dev/null
+  py2_time=$(sh -c "time python2 scripts/show-features.py $file >> results/p2-$file_name.out 2>/dev/null" 2>&1)
+
+  int $py3_time
+  if (($int > $threshold_py3_time))
+  then
+    percentage=$(bc <<< "scale=3; $py2_time/$py3_time*100 + 0.5")
+    int $percentage
+    if (($int < $threshold_py3_time))
+    then
+      echo -n "  SLOWER ($percentage): "
+    fi
+  fi
+  echo "  PY2($py2_time) PY3($py3_time)"
+done
+
+threshold_features=98
+counter=0
+average=0
+results_for() {
+  py3=$(cat "results/p3-$file_name.out" | grep "$1" | wc -l)
+  py2=$(cat "results/p2-$file_name.out" | grep "$1" | wc -l)
+  if (($py2 > 0))
+  then
+    percentage=$(bc <<< "scale=2; 100*$py3/$py2")
+    average=$(bc <<< "scale=2; $percentage + $average")
+    count=$(($count + 1))
+    int $percentage
+    if (($int < $threshold_features))
+    then
+      echo -e "$1: py2($py2) py3($py3) $percentage% - $file_name"
+    fi
+  fi
+}
+
+rm tests/data/*.viv 2>/dev/null
+echo -e '\nRESULTS:'
+for file in tests/data/*
+do
+  file_name=$(basename $file)
+  if test -f "results/p2-$file_name.out"; then
+    results_for 'insn'
+    results_for 'file'
+    results_for 'func'
+    results_for 'bb'
+  fi
+done
+
+average=$(bc <<< "scale=2; $average/$count")
+echo "TOTAL: $average"

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ if sys.version_info >= (3, 0):
     # py3
     requirements.append("halo")
     requirements.append("networkx")
+    requirements.append("vivisect @ git+https://github.com/Ana06/vivisect@py-3#egg=vivisect")
+    requirements.append("viv-utils==0.3.19")
     requirements.append("smda==1.5.13")
 else:
     # py2

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if sys.version_info >= (3, 0):
     # py3
     requirements.append("halo")
     requirements.append("networkx")
-    requirements.append("vivisect @ git+https://github.com/Ana06/vivisect@py-3#egg=vivisect")
+    requirements.append("vivisect==1.0.0")
     requirements.append("viv-utils==0.3.19")
     requirements.append("smda==1.5.13")
 else:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -520,11 +520,7 @@ def do_test_feature_count(get_extractor, sample, scope, feature, expected):
 
 
 def get_extractor(path):
-    if sys.version_info >= (3, 0):
-        extractor = get_smda_extractor(path)
-    else:
-        extractor = get_viv_extractor(path)
-
+    extractor = get_viv_extractor(path)
     # overload the extractor so that the fixture exposes `extractor.path`
     setattr(extractor, "path", path)
     return extractor

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,6 +7,7 @@
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 import sys
+import json
 import textwrap
 
 import pytest
@@ -367,15 +368,18 @@ def test_not_render_rules_also_matched(z9324d_extractor, capsys):
     assert "create TCP socket" in std.out
 
 
-# It tests main works with different backends. It doesn't test that the backend
-# is actually called.
+# It tests main works with different backends
 def test_backend_option(capsys):
     if sys.version_info > (3, 0):
         path = get_data_path_by_name("pma16-01")
-        assert capa.main.main([path, "-b", capa.main.BACKEND_VIV]) == 0
+        assert capa.main.main([path, "-j", "-b", capa.main.BACKEND_VIV]) == 0
         std = capsys.readouterr()
-        assert "check for PEB NtGlobalFlag flag (24 matches)" in std.out
+        std_json = json.loads(std.out)
+        assert std_json["meta"]["analysis"]["extractor"] == "VivisectFeatureExtractor"
+        assert len(std_json["rules"]) > 0
 
-        assert capa.main.main([path, "-b", capa.main.BACKEND_SMDA]) == 0
+        assert capa.main.main([path, "-j", "-b", capa.main.BACKEND_SMDA]) == 0
         std = capsys.readouterr()
-        assert "check for PEB NtGlobalFlag flag (24 matches)" in std.out
+        std_json = json.loads(std.out)
+        assert std_json["meta"]["analysis"]["extractor"] == "SmdaFeatureExtractor"
+        assert len(std_json["rules"]) > 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -365,3 +365,17 @@ def test_not_render_rules_also_matched(z9324d_extractor, capsys):
     assert "act as TCP client" in std.out
     assert "connect TCP socket" in std.out
     assert "create TCP socket" in std.out
+
+
+# It tests main works with different backends. It doesn't test that the backend
+# is actually called.
+def test_backend_option(capsys):
+    if sys.version_info > (3, 0):
+        path = get_data_path_by_name("pma16-01")
+        assert capa.main.main([path, "-b", capa.main.BACKEND_VIV]) == 0
+        std = capsys.readouterr()
+        assert "check for PEB NtGlobalFlag flag (24 matches)" in std.out
+
+        assert capa.main.main([path, "-b", capa.main.BACKEND_SMDA]) == 0
+        std = capsys.readouterr()
+        assert "check for PEB NtGlobalFlag flag (24 matches)" in std.out

--- a/tests/test_viv_features.py
+++ b/tests/test_viv_features.py
@@ -16,8 +16,7 @@ from fixtures import *
     indirect=["sample", "scope"],
 )
 def test_viv_features(sample, scope, feature, expected):
-    with xfail(sys.version_info >= (3, 0), reason="vivsect only works on py2"):
-        do_test_feature_presence(get_viv_extractor, sample, scope, feature, expected)
+    do_test_feature_presence(get_viv_extractor, sample, scope, feature, expected)
 
 
 @parametrize(
@@ -26,5 +25,4 @@ def test_viv_features(sample, scope, feature, expected):
     indirect=["sample", "scope"],
 )
 def test_viv_feature_counts(sample, scope, feature, expected):
-    with xfail(sys.version_info >= (3, 0), reason="vivsect only works on py2"):
-        do_test_feature_count(get_viv_extractor, sample, scope, feature, expected)
+    do_test_feature_count(get_viv_extractor, sample, scope, feature, expected)


### PR DESCRIPTION
Vivisect has moved to Python3: https://github.com/vivisect/vivisect/pull/328 This PR allows to run vivisect with Python3 in capa and provides an option to select the backend (vivisect is the default but this can be easily changed). I am using the following version of vivisect (which includes fixes for some bugs I have found and I need to report to vivisect): https://github.com/Ana06/vivisect/tree/py-3

`scripts/vivisect-py2-vs-py3.sh` tests the performance of vivisect Python 2 vs 3 by counting the number
of feature of each type extracted for every binary in `tests/data`. I run it using the code in this PR with Python 2 and vivisect 0.2.0 and with Python 3 and https://github.com/Ana06/vivisect/tree/py-3. **Python3 extracted in average 101.01% percentage of the features that Python2 extracted** and there are no files which perform specially bad. I have enabled tests for vivisect in Python3 and they are also working. With this I think we can conclude that vivisect works in Python3! :tada:

The [regression introduced in vivisec 0.2.0](https://github.com/fireeye/capa/pull/413) seems to be fixed (at least the test doesn't fail anymore).