### PR TITLE
mirror show-capabilities-by-function to enable multiple backends

### DIFF
--- a/scripts/show-capabilities-by-function.py
+++ b/scripts/show-capabilities-by-function.py
@@ -63,7 +63,6 @@ import capa.render
 import capa.features
 import capa.render.utils as rutils
 import capa.features.freeze
-import capa.features.extractors.viv
 from capa.helpers import get_file_taste
 
 logger = logging.getLogger("capa.show-capabilities-by-function")


### PR DESCRIPTION
Enable use of multiple backends in `show-features.py`, similar to `show-capabilities-by-function.py`. Also, removing `viv` dependency from `show-capabilities-by-function.py` to enable use of multiple backends.