### PR TITLE
check for unmapped addresses when resolving data references

### DIFF
--- a/capa/features/extractors/ida/helpers.py
+++ b/capa/features/extractors/ida/helpers.py
@@ -351,6 +351,10 @@ def find_data_reference_from_insn(insn, max_depth=10):
             # break if circular reference
             break
 
+        if not idaapi.is_mapped(data_refs[0]):
+            # break if address is not mapped
+            break
+
         depth += 1
         if depth > max_depth:
             # break if max depth


### PR DESCRIPTION
I ran into a situation where IDA was returning unmapped addresses when calling `idautils.DataRefsFrom`, so we need to check for this.