### PR TITLE
explorer: adding option to show results by function

### DIFF
--- a/capa/ida/plugin/item.py
+++ b/capa/ida/plugin/item.py
@@ -35,20 +35,19 @@ def location_to_hex(location):
 class CapaExplorerDataItem(object):
     """store data for CapaExplorerDataModel"""
 
-    def __init__(self, parent, data):
+    def __init__(self, parent, data, can_check=True):
         """initialize item"""
         self.pred = parent
         self._data = data
         self.children = []
         self._checked = False
+        self._can_check = can_check
 
         # default state for item
-        self.flags = (
-            QtCore.Qt.ItemIsEnabled
-            | QtCore.Qt.ItemIsSelectable
-            | QtCore.Qt.ItemIsTristate
-            | QtCore.Qt.ItemIsUserCheckable
-        )
+        self.flags = QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
+
+        if self._can_check:
+            self.flags = self.flags | QtCore.Qt.ItemIsUserCheckable | QtCore.Qt.ItemIsTristate
 
         if self.pred:
             self.pred.appendChild(self)
@@ -69,6 +68,10 @@ class CapaExplorerDataItem(object):
         @param checked: True, item checked, False item not checked
         """
         self._checked = checked
+
+    def canCheck(self):
+        """ """
+        return self._can_check
 
     def isChecked(self):
         """get item is checked"""
@@ -165,7 +168,7 @@ class CapaExplorerRuleItem(CapaExplorerDataItem):
 
     fmt = "%s (%d matches)"
 
-    def __init__(self, parent, name, namespace, count, source):
+    def __init__(self, parent, name, namespace, count, source, can_check=True):
         """initialize item
 
         @param parent: parent node
@@ -175,7 +178,7 @@ class CapaExplorerRuleItem(CapaExplorerDataItem):
         @param source: rule source (tooltip)
         """
         display = self.fmt % (name, count) if count > 1 else name
-        super(CapaExplorerRuleItem, self).__init__(parent, [display, "", namespace])
+        super(CapaExplorerRuleItem, self).__init__(parent, [display, "", namespace], can_check)
         self._source = source
 
     @property
@@ -208,14 +211,14 @@ class CapaExplorerFunctionItem(CapaExplorerDataItem):
 
     fmt = "function(%s)"
 
-    def __init__(self, parent, location):
+    def __init__(self, parent, location, can_check=True):
         """initialize item
 
         @param parent: parent node
         @param location: virtual address of function as seen by IDA
         """
         super(CapaExplorerFunctionItem, self).__init__(
-            parent, [self.fmt % idaapi.get_name(location), location_to_hex(location), ""]
+            parent, [self.fmt % idaapi.get_name(location), location_to_hex(location), ""], can_check
         )
 
     @property


### PR DESCRIPTION
Adding option to show results by function, in addition to results by rule. This new option helps users quickly gain a better understanding of what functions may do depending on the rules they matched.

modeled after `scripts/show-results-by-function.py`.

results by rule (current):

![by_rule](https://user-images.githubusercontent.com/42192796/108728947-46dba800-74e7-11eb-8878-a96a115482b9.png)

results by function:

![by_function](https://user-images.githubusercontent.com/42192796/108729003-52c76a00-74e7-11eb-813a-80989f27ae2e.png)