### PR TITLE
viv: ignore empty branch targets

### DIFF
--- a/capa/features/extractors/viv/insn.py
+++ b/capa/features/extractors/viv/insn.py
@@ -500,6 +500,7 @@ def extract_insn_cross_section_cflow(f, bb, insn):
     """
     for va, flags in insn.getBranches():
         if va is None:
+            # va may be none for dynamic branches that haven't been resolved, such as `jmp eax`.
             continue
 
         if flags & envi.BR_FALL:

--- a/capa/features/extractors/viv/insn.py
+++ b/capa/features/extractors/viv/insn.py
@@ -499,6 +499,9 @@ def extract_insn_cross_section_cflow(f, bb, insn):
     inspect the instruction for a CALL or JMP that crosses section boundaries.
     """
     for va, flags in insn.getBranches():
+        if va is None:
+            continue
+
         if flags & envi.BR_FALL:
             continue
 


### PR DESCRIPTION
but what does this really mean? why would `getBranches` return `None`?

closes #441