### PR TITLE
doc: Improve README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 ![capa](.github/logo.png)
 
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/flare-capa)
-[![CI status](https://github.com/fireeye/capa/workflows/CI/badge.svg)](https://github.com/fireeye/capa/actions?query=workflow%3ACI+event%3Apush+branch%3Amaster)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/flare-capa)](https://pypi.org/project/flare-capa)
+[![Last release](https://img.shields.io/github/v/release/fireeye/capa)](https://github.com/fireeye/capa/release)
 [![Number of rules](https://img.shields.io/badge/rules-469-blue.svg)](https://github.com/fireeye/capa-rules)
+[![CI status](https://github.com/fireeye/capa/workflows/CI/badge.svg)](https://github.com/fireeye/capa/actions?query=workflow%3ACI+event%3Apush+branch%3Amaster)
+[![Downloads](https://img.shields.io/github/downloads/fireeye/capa/total)](https://github.com/fireeye/capa/release)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE.txt)
 
 capa detects capabilities in executable files.


### PR DESCRIPTION
- Add a link to the `PyPI - Python Version` badge. Otherwise it opens the image when clicking on it, which is inconsistent with the other badges. I arrived too late to point this out in: https://github.com/fireeye/capa/pull/477
- Add release badge with last release version. This may help users to realize that a new version has been released.
- Add downloads badge.
- Order labels by color.

Closes https://github.com/fireeye/capa/issues/196