### PR TITLE
setup: bump viv-utils to 0.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ requirements = [
     "ruamel.yaml",
     "wcwidth",
     "ida-settings==2.1.0",
+    "viv-utils==0.5.0",
 ]
 
 if sys.version_info >= (3, 0):
@@ -28,14 +29,12 @@ if sys.version_info >= (3, 0):
     requirements.append("halo")
     requirements.append("networkx")
     requirements.append("vivisect==1.0.0")
-    requirements.append("viv-utils==0.3.19")
     requirements.append("smda==1.5.13")
 else:
     # py2
     requirements.append("enum34==1.1.6")  # v1.1.6 is needed by halo 0.0.30 / spinners 0.0.24
     requirements.append("halo==0.0.30")  # halo==0.0.30 is the last version to support py2.7
     requirements.append("vivisect==0.2.1")
-    requirements.append("viv-utils==0.3.19")
     requirements.append("networkx==2.2")  # v2.2 is last version supported by Python 2.7
     requirements.append("backports.functools-lru-cache")
 


### PR DESCRIPTION
In viv-utils `getWorkspace` raises `IncompatibleVivVersion` on Python 3 when `vw.loadWorkspace(viv_file)` raises `UnicodeDecodeError`. Fixes https://github.com/fireeye/capa/issues/469