### PR TITLE
ensure LF end of line

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -301,6 +301,16 @@ class FeatureNtdllNtoskrnlApi(Lint):
         return False
 
 
+class FormatLineFeedEOL(Lint):
+    name = "line(s) end with CRLF (\\r\\n)"
+    recommendation = "convert line endings to LF (\\n) for example using dos2unix"
+
+    def check_rule(self, ctx, rule):
+        if len(rule.definition.split("\r\n")) > 0:
+            return False
+        return True
+
+
 class FormatSingleEmptyLineEOF(Lint):
     name = "EOF format"
     recommendation = "end file with a single empty line"
@@ -385,6 +395,7 @@ def lint_features(ctx, rule):
 
 
 FORMAT_LINTS = (
+    FormatLineFeedEOL(),
     FormatSingleEmptyLineEOF(),
     FormatIncorrect(),
 )
@@ -554,7 +565,7 @@ def main(argv=None):
 
     samples_path = os.path.join(os.path.dirname(__file__), "..", "tests", "data")
 
-    parser = argparse.ArgumentParser(description="A program.")
+    parser = argparse.ArgumentParser(description="Lint capa rules.")
     capa.main.install_common_args(parser, wanted={"tag"})
     parser.add_argument("rules", type=str, help="Path to rules")
     parser.add_argument("--samples", type=str, default=samples_path, help="Path to samples")
@@ -566,8 +577,12 @@ def main(argv=None):
     args = parser.parse_args(args=argv)
     capa.main.handle_common_args(args)
 
-    logging.getLogger("capa").setLevel(logging.CRITICAL)
-    logging.getLogger("viv_utils").setLevel(logging.CRITICAL)
+    if args.debug:
+        logging.getLogger("capa").setLevel(logging.DEBUG)
+        logging.getLogger("viv_utils").setLevel(logging.DEBUG)
+    else:
+        logging.getLogger("capa").setLevel(logging.ERROR)
+        logging.getLogger("viv_utils").setLevel(logging.ERROR)
 
     time0 = time.time()
 


### PR DESCRIPTION
closes #483 slightly different to #484 (I'm fine either way)

closes #482 by lint ensuring there's only CRLF line breaks and by introducing `.gitattributes` in https://github.com/fireeye/capa-rules/pull/298