### PR TITLE
ci: add capa release link to capa-rules tag

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -15,7 +15,12 @@ jobs:
         repository: fireeye/capa-rules
         token: ${{ secrets.CAPA_TOKEN }}
     - name: Tag capa-rules
-      run: git tag ${{ github.event.release.tag_name }}
+      run: |
+        # user information is needed to create annotated tags (with a message)
+        git config user.email 'capa-dev@fireeye.com'
+        git config user.name 'Capa Bot'
+        name=${{ github.event.release.tag_name }}
+        git tag $name -m "https://github.com/fireeye/capa/releases/$name"
     - name: Push tag to capa-rules
       uses: ad-m/github-push-action@master
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Development
 
+- ci: add capa release link to capa-rules tag #517 @Ana06
+
 ### Raw diffs
 - [capa v1.6.1...master](https://github.com/fireeye/capa/compare/v1.6.1...master)
 - [capa-rules v1.6.1...master](https://github.com/fireeye/capa-rules/compare/v1.6.1...master)


### PR DESCRIPTION
GitHub displays the commit's message of the tag if no description is given, which is ugly. Use annotated tags which include a message. Use the release link as message, as this is useful information.

This is the difference between a tag created with the previous action and with the changes:

![Screenshot 2021-04-07 at 18 59 16](https://user-images.githubusercontent.com/16052290/113905364-5d0da100-97d3-11eb-80ca-5d31dc508007.png)

### Type of change

Please update the [CHANGELOG.md](/CHANGELOG.md)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
  - [ ] I have made the corresponding changes to the documentation
- [X] Other

### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] No new tests needed
