### PR TITLE
explorer: add analyze option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ It includes many new rules, including all new techniques introduced in MITRE ATT
 - show-features: don't show features from library functions #569 @williballenthin
 - linter: summarize results at the end #571 @williballenthin
 - linter: check for `or` with always true child statement, e.g. `optional`, colors #348 @mr-tz
+- explorer: add argument to control whether to automatically analyze when running capa explorer #548 @Ana06
 
 ### Breaking Changes
 

--- a/capa/ida/plugin/README.md
+++ b/capa/ida/plugin/README.md
@@ -79,6 +79,7 @@ You can install capa explorer using the following steps:
 
 1. Open IDA and analyze a supported file type (select the `Manual Load` and `Load Resources` options in IDA for best results)
 2. Open capa explorer in IDA by navigating to `Edit > Plugins > FLARE capa explorer` or using the keyboard shortcut `Alt+F5`
+   You can also use `ida_loader.load_and_run_plugin("capa_explorer", arg)`. `arg` is a bitflag for which setting the LSB enables automatic analysis. See `capa.ida.plugin.form.Options` for more details.
 3. Select the `Program Analysis` tab
 4. Click the `Analyze` button
 

--- a/capa/ida/plugin/__init__.py
+++ b/capa/ida/plugin/__init__.py
@@ -54,8 +54,14 @@ class CapaExplorerPlugin(idaapi.plugin_t):
         pass
 
     def run(self, arg):
-        """called when IDA is running the plugin as a script"""
-        self.form = CapaExplorerForm(self.PLUGIN_NAME)
+        """
+        called when IDA is running the plugin as a script
+
+        args:
+          arg (int): bitflag. Setting LSB enables automatic analysis upon
+          loading. The other bits are currently undefined. See `form.Options`.
+        """
+        self.form = CapaExplorerForm(self.PLUGIN_NAME, arg)
         return True
 
 

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -230,7 +230,7 @@ class CapaSettingsInputDialog(QtWidgets.QDialog):
 class CapaExplorerForm(idaapi.PluginForm):
     """form element for plugin interface"""
 
-    def __init__(self, name):
+    def __init__(self, name, option=0):
         """initialize form elements"""
         super(CapaExplorerForm, self).__init__()
 
@@ -277,6 +277,9 @@ class CapaExplorerForm(idaapi.PluginForm):
         self.view_rulegen_status_label = None
 
         self.Show()
+
+        if option == 1:
+            self.analyze_program()
 
     def OnCreate(self, form):
         """called when plugin form is created

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -44,6 +44,13 @@ CAPA_SETTINGS_RULE_PATH = "rule_path"
 CAPA_SETTINGS_RULEGEN_AUTHOR = "rulegen_author"
 CAPA_SETTINGS_RULEGEN_SCOPE = "rulegen_scope"
 
+from enum import IntFlag
+
+
+class Options(IntFlag):
+    DEFAULT = 0
+    ANALYZE = 1  # Runs the analysis when starting the explorer
+
 
 def write_file(path, data):
     """ """
@@ -230,7 +237,7 @@ class CapaSettingsInputDialog(QtWidgets.QDialog):
 class CapaExplorerForm(idaapi.PluginForm):
     """form element for plugin interface"""
 
-    def __init__(self, name, option=0):
+    def __init__(self, name, option=Options.DEFAULT):
         """initialize form elements"""
         super(CapaExplorerForm, self).__init__()
 
@@ -278,7 +285,7 @@ class CapaExplorerForm(idaapi.PluginForm):
 
         self.Show()
 
-        if option == 1:
+        if (option & Options.ANALYZE) == Options.ANALYZE:
             self.analyze_program()
 
     def OnCreate(self, form):


### PR DESCRIPTION
I would like to load capa explorer with an script and that it runs the
analysis without needing extra clicks. Introduce an analyze option for
this.

Loading capa explorer from the UI or with Alt+F5 behaves as before. The
following command as well:
```
ida_loader.load_and_run_plugin("capa_explorer", 0)
```
But the following command automatically runs the analysis without extra
clicks:
```
ida_loader.load_and_run_plugin("capa_explorer", 1)
```

Example of where I am using this:
https://github.com/Ana06/idapython/blob/master/idapythonrc.py#L22

Closes https://github.com/fireeye/capa/issues/546

### Documentation

- [x] I have updated the [CHANGELOG.md](/CHANGELOG.md), this is required for:
  - Bug fixes (non-breaking change which fixes an issue)
  - New features (non-breaking change which adds functionality)
  - Breaking changes (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
  - [x] I have made the corresponding changes to the documentation

### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] No new tests needed
