### PR TITLE
Update CHANGELOG and release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,79 @@
 ## master (unreleased)
 
 The first Python 3 ONLY capa version.
+It includes many new rules, including all new techniques introduced in MITRE ATT&CK v9.
 
 ### New Features
 
 - main: auto detect shellcode based on file extension #516 @mr-tz
 - main: use FLIRT signatures to identify and ignore library code #446 @williballenthin
+- explorer: IDA 7.6 support #497 @williballenthin
 
-### New Rules
+### New Rules (63)
+
+- anti-analysis/packer/amber/packed-with-amber @gormaniac
+- collection/file-managers/gather-3d-ftp-information @re-fox
+- collection/file-managers/gather-alftp-information @re-fox
+- collection/file-managers/gather-bitkinex-information @re-fox
+- collection/file-managers/gather-blazeftp-information @re-fox
+- collection/file-managers/gather-bulletproof-ftp-information @re-fox
+- collection/file-managers/gather-classicftp-information @re-fox
+- collection/file-managers/gather-coreftp-information @re-fox
+- collection/file-managers/gather-cuteftp-information @re-fox
+- collection/file-managers/gather-cyberduck-information @re-fox
+- collection/file-managers/gather-direct-ftp-information @re-fox
+- collection/file-managers/gather-directory-opus-information @re-fox
+- collection/file-managers/gather-expandrive-information @re-fox
+- collection/file-managers/gather-faststone-browser-information @re-fox
+- collection/file-managers/gather-fasttrack-ftp-information @re-fox
+- collection/file-managers/gather-ffftp-information @re-fox
+- collection/file-managers/gather-filezilla-information @re-fox
+- collection/file-managers/gather-flashfxp-information @re-fox
+- collection/file-managers/gather-fling-ftp-information @re-fox
+- collection/file-managers/gather-freshftp-information @re-fox
+- collection/file-managers/gather-frigate3-information @re-fox
+- collection/file-managers/gather-ftp-commander-information @re-fox
+- collection/file-managers/gather-ftp-explorer-information @re-fox
+- collection/file-managers/gather-ftp-voyager-information @re-fox
+- collection/file-managers/gather-ftpgetter-information @re-fox
+- collection/file-managers/gather-ftpinfo-information @re-fox
+- collection/file-managers/gather-ftpnow-information @re-fox
+- collection/file-managers/gather-ftprush-information @re-fox
+- collection/file-managers/gather-ftpshell-information @re-fox
+- collection/file-managers/gather-global-downloader-information @re-fox
+- collection/file-managers/gather-goftp-information @re-fox
+- collection/file-managers/gather-leapftp-information @re-fox
+- collection/file-managers/gather-netdrive-information @re-fox
+- collection/file-managers/gather-nexusfile-information @re-fox
+- collection/file-managers/gather-nova-ftp-information @re-fox
+- collection/file-managers/gather-robo-ftp-information @re-fox
+- collection/file-managers/gather-securefx-information @re-fox
+- collection/file-managers/gather-smart-ftp-information @re-fox
+- collection/file-managers/gather-softx-ftp-information @re-fox
+- collection/file-managers/gather-southriver-webdrive-information @re-fox
+- collection/file-managers/gather-staff-ftp-information @re-fox
+- collection/file-managers/gather-total-commander-information @re-fox
+- collection/file-managers/gather-turbo-ftp-information @re-fox
+- collection/file-managers/gather-ultrafxp-information @re-fox
+- collection/file-managers/gather-winscp-information @re-fox
+- collection/file-managers/gather-winzip-information @re-fox
+- collection/file-managers/gather-wise-ftp-information @re-fox
+- collection/file-managers/gather-ws-ftp-information @re-fox
+- collection/file-managers/gather-xftp-information @re-fox
+- data-manipulation/compression/decompress-data-using-aplib @r3c0nst @mr-tz
+- host-interaction/bootloader/disable-code-signing @williballenthin
+- host-interaction/bootloader/manipulate-boot-configuration @williballenthin
+- host-interaction/driver/disable-driver-code-integrity @williballenthin
+- host-interaction/file-system/bypass-mark-of-the-web @williballenthin
+- host-interaction/network/domain/get-domain-information @recvfrom
+- host-interaction/session/get-logon-sessions @recvfrom
+- linking/runtime-linking/resolve-function-by-fin8-fasthash @r3c0nst @mr-tz
+- nursery/build-docker-image @williballenthin
+- nursery/create-container @williballenthin
+- nursery/encrypt-data-using-fakem-cipher @mike-hunhoff
+- nursery/list-containers @williballenthin
+- nursery/run-in-container @williballenthin
+- persistence/registry/appinitdlls/disable-appinit_dlls-code-signature-enforcement @williballenthin
 
 ### Bug Fixes
 
@@ -20,6 +86,8 @@ The first Python 3 ONLY capa version.
 - py3: drop Python 2 support #480 @Ana06
 - deps: bump ruamel yaml parser to 0.17.4 #519 @williballenthin
 - explorer: explain how to install IDA 7.6 patch to enable the plugin #528 @williballenthin
+- explorer: document IDA 7.6sp1 as alternative to the patch #536 @Ana06
+- rules: update ATT&CK and MBC mappings https://github.com/fireeye/capa-rules/pull/317 @williballenthin
 
 ### Development
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ The first Python 3 ONLY capa version.
 - [capa-rules v1.6.1...master](https://github.com/fireeye/capa-rules/compare/v1.6.1...master)
 
 
+## v1.6.3 (2021-04-29)
+
+This release adds IDA 7.6 support to capa.
+
+### Changes
+
+- IDA 7.6 support @williballenthin @Ana06
+
+### Raw diffs
+
+  - [capa v1.6.2...v1.6.3](https://github.com/fireeye/capa/compare/v1.6.2...v1.6.3)
+
+
 ## v1.6.2 (2021-04-13)
 
 This release backports a fix to capa 1.6: The Windows binary was built with Python 3.9 which doesn't support Windows 7.
@@ -43,7 +56,7 @@ This release backports a fix to capa 1.6: The Windows binary was built with Pyth
 ### Raw diffs
 
   - [capa v1.6.1...v1.6.2](https://github.com/fireeye/capa/compare/v1.6.1...v1.6.2)
-  - [capa-rules v1.6.1...v1.6.2](https://github.com/fireeye/capa-rules/compare/v1.6.1...v1.6.2)
+
 
 ## v1.6.1 (2021-04-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ It includes many new rules, including all new techniques introduced in MITRE ATT
 - nursery/list-containers @williballenthin
 - nursery/run-in-container @williballenthin
 - persistence/registry/appinitdlls/disable-appinit_dlls-code-signature-enforcement @williballenthin
+-
 
 ### Bug Fixes
 

--- a/doc/release.md
+++ b/doc/release.md
@@ -43,4 +43,5 @@
 - [ ] After PR review, merge the PR and [create the release in GH](https://github.com/fireeye/capa/releases/new) using text from the [CHANGELOG.md](https://github.com/fireeye/capa/blob/master/CHANGELOG.md).
 - [ ] Verify GH actions [upload artifacts](https://github.com/fireeye/capa/releases), [publish to PyPI](https://pypi.org/project/flare-capa) and [create a tag in capa rules](https://github.com/fireeye/capa-rules/tags) upon completion.
 - [ ] [Spread the word](https://twitter.com)
+- [ ] Update internal service
 

--- a/doc/release.md
+++ b/doc/release.md
@@ -24,7 +24,9 @@
 
     ### New Features
 
-    ### New Rules
+    ### New Rules (0)
+
+    -
 
     ### Bug Fixes
 


### PR DESCRIPTION
Add missing changes to CHANGELOG. It should be up-to-date now, with the exception of the dependencies updates which I think need discussion. I am planing to send a PR with a GitHub action which automatically updates the rules. If new PRs are merge till then, we should remember to add those entries to the CHANGELOG.

Also update release checklist.

I haven't add a CHANGELOG entry for this PR, but once the new rules are automatize, I can add an entry in development mentioning this PR as well. As this point this PR just updates the CHANGELOG (although it plans for automation).