### PR TITLE
lint statements for single child statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ It includes many new rules, including all new techniques introduced in MITRE ATT
 - ci: add capa release link to capa-rules tag #517 @Ana06
 - ci, changelog: update `New Rules` section in CHANGELOG automatically https://github.com/fireeye/capa-rules/pull/374 #549 @Ana06
 - ci, changelog: support multiple author in sync GH https://github.com/fireeye/capa-rules/pull/378 @Ana06
+- ci, lint: check statements for single child statements #563 @mr-tz
 
 ### Raw diffs
 


### PR DESCRIPTION
### Description

addresses https://github.com/fireeye/capa-rules/issues/382

### Documentation

- [x] I have updated the [CHANGELOG.md](/CHANGELOG.md), this is required for:
  - Bug fixes (non-breaking change which fixes an issue)
  - New features (non-breaking change which adds functionality)
  - Breaking changes (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
  - [ ] I have made the corresponding changes to the documentation

### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] No new tests needed
