### PR TITLE
Update capa2yara.py

### DIFF
--- a/scripts/capa2yara.py
+++ b/scripts/capa2yara.py
@@ -295,7 +295,7 @@ def convert_rule(rule, rulename, cround, depth):
             # change begining of line to null byte, e.g. /^open => /\x00open (not word boundary because we're not looking for the begining of a word in a text but usually a function name if there's ^ in a capa rule)
             regex = re.sub(r"^\^", r"\\x00", regex)
 
-            #regex = re.sub(r"^\^", r"\\b", regex)
+            # regex = re.sub(r"^\^", r"\\b", regex)
 
             regex = "/" + regex + "/"
             if count:


### PR DESCRIPTION
bugfix: https://github.com/fireeye/capa-rules/blob/master/collection/get-geographical-location.yml hit an far too many files with /\bcity opposed to the intention of the capa rule ti just hit in function names. changed to /\x00city.
