### PR TITLE
json: capture all strings matching regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ It includes many new rules, including all new techniques introduced in MITRE ATT
 - linter: summarize results at the end #571 @williballenthin
 - meta: added `library_functions` field, `feature_counts.functions` does not include library functions any more #562 @mr-tz
 - linter: check for `or` with always true child statement, e.g. `optional`, colors #348 @mr-tz
+- json: breaking change: record all matching strings for regex #159 @williballenthin
 
 ### Development
 

--- a/capa/features/__init__.py
+++ b/capa/features/__init__.py
@@ -216,7 +216,10 @@ class _MatchedRegex(Regex):
         self.matches = matches
 
     def __str__(self):
-        return 'regex(string =~ %s, matches = %s)' % (self.value, ", ".join(map(lambda s: '"' + s + '"', (self.matches or {}).keys())))
+        return "regex(string =~ %s, matches = %s)" % (
+            self.value,
+            ", ".join(map(lambda s: '"' + s + '"', (self.matches or {}).keys())),
+        )
 
 
 class StringFactory(object):

--- a/capa/ida/plugin/model.py
+++ b/capa/ida/plugin/model.py
@@ -12,6 +12,8 @@ import idc
 import idaapi
 from PyQt5 import QtGui, QtCore
 
+import capa.rules
+import capa.features
 import capa.ida.helpers
 import capa.render.utils as rutils
 from capa.ida.plugin.item import (
@@ -556,7 +558,7 @@ class CapaExplorerDataModel(QtCore.QAbstractItemModel):
 
         if feature["type"] == "regex":
             return CapaExplorerStringViewItem(
-                parent, display, location, '"%s"' % capa.features.escape_string(feature["match"])
+                parent, display, location, "\n".join(map(lambda s: '"' + capa.features.escape_string(s) + '"', feature["matches"].keys()))
             )
 
         if feature["type"] == "basicblock":

--- a/capa/ida/plugin/model.py
+++ b/capa/ida/plugin/model.py
@@ -557,9 +557,14 @@ class CapaExplorerDataModel(QtCore.QAbstractItemModel):
             )
 
         if feature["type"] == "regex":
-            return CapaExplorerStringViewItem(
-                parent, display, location, "\n".join(map(lambda s: '"' + capa.features.escape_string(s) + '"', feature["matches"].keys()))
-            )
+            for s, locations in feature["matches"].items():
+                if location in locations:
+                    return CapaExplorerStringViewItem(
+                        parent, display, location, '"' + capa.features.escape_string(s) + '"'
+                    )
+
+            # programming error: the given location should always be found in the regex matches
+            raise ValueError("regex match at location not found")
 
         if feature["type"] == "basicblock":
             return CapaExplorerBlockItem(parent, location)

--- a/capa/render/__init__.py
+++ b/capa/render/__init__.py
@@ -72,7 +72,7 @@ def convert_feature_to_result_document(feature):
     if feature.description:
         result["description"] = feature.description
     if feature.name == "regex":
-        result["match"] = feature.match
+        result["matches"] = feature.matches
     return result
 
 

--- a/capa/render/vverbose.py
+++ b/capa/render/vverbose.py
@@ -6,10 +6,9 @@
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-import collections
-
 import tabulate
 
+import capa.features
 import capa.rules
 import capa.render.utils as rutils
 import capa.render.verbose
@@ -85,31 +84,50 @@ def render_statement(ostream, match, statement, indent=0):
         raise RuntimeError("unexpected match statement type: " + str(statement))
 
 
+def render_string_value(s):
+    return '"%s"' % capa.features.escape_string(s)
+
+
 def render_feature(ostream, match, feature, indent=0):
     ostream.write("  " * indent)
 
     key = feature["type"]
     value = feature[feature["type"]]
-    if key == "regex":
-        key = "string"  # render string for regex to mirror the rule source
-        value = feature["match"]  # the match provides more information than the value for regex
 
-    if key == "string":
-        value = '"%s"' % capa.features.escape_string(value)
+    if key != "regex":
+        # like:
+        #   number: 10 = SOME_CONSTANT @ 0x401000
+        if key == "string":
+            value = render_string_value(value)
 
-    ostream.write(key)
-    ostream.write(": ")
+        ostream.write(key)
+        ostream.write(": ")
 
-    if value:
-        ostream.write(rutils.bold2(value))
+        if value:
+            ostream.write(rutils.bold2(value))
 
-        if "description" in feature:
-            ostream.write(capa.rules.DESCRIPTION_SEPARATOR)
-            ostream.write(feature["description"])
+            if "description" in feature:
+                ostream.write(capa.rules.DESCRIPTION_SEPARATOR)
+                ostream.write(feature["description"])
 
-    render_locations(ostream, match)
-    ostream.write("\n")
+        render_locations(ostream, match)
+        ostream.write("\n")
+    else:
+        # like:
+        #  regex: /blah/ = SOME_CONSTANT
+        #    - "foo blah baz" @ 0x401000
+        #    - "aaa blah bbb" @ 0x402000, 0x403400
+        ostream.write(key)
+        ostream.write(": ")
+        ostream.write(value)
+        ostream.write("\n")
 
+        for match, locations in sorted(feature["matches"].items(), key=lambda p: p[0]):
+            ostream.write("  " * (indent + 1))
+            ostream.write("- ")
+            ostream.write(rutils.bold2(render_string_value(match)))
+            render_locations(ostream, {"locations": locations})
+            ostream.write("\n")
 
 def render_node(ostream, match, node, indent=0):
     if node["type"] == "statement":

--- a/capa/render/vverbose.py
+++ b/capa/render/vverbose.py
@@ -8,8 +8,8 @@
 
 import tabulate
 
-import capa.features
 import capa.rules
+import capa.features
 import capa.render.utils as rutils
 import capa.render.verbose
 
@@ -128,6 +128,7 @@ def render_feature(ostream, match, feature, indent=0):
             ostream.write(rutils.bold2(render_string_value(match)))
             render_locations(ostream, {"locations": locations})
             ostream.write("\n")
+
 
 def render_node(ostream, match, node, indent=0):
     if node["type"] == "statement":


### PR DESCRIPTION
previously, when we evaluated a regex, we short circuited after the first match, capturing a single string with locations. but regexes can match multiple different strings, so in this PR we capture all matching strings and each of their locations. this doesn't change rule behavior (unless maybe theres a `count(regex(foo))` or something?) but it makes our feature reporting much more complete.

this requires a breaking change to the JSON document: a regex node now has a child `matches` that maps from matching string to its locations. this used to be `match` that contained just the single matching string.

our renders and IDA plugin have been updated.

closes #159 

![image](https://user-images.githubusercontent.com/156560/120018421-5f56d500-bfa4-11eb-9a0f-a1cdddce9430.png)

![image](https://user-images.githubusercontent.com/156560/120019988-5f57d480-bfa6-11eb-9cc6-d2dedd35c20d.png)

![image](https://user-images.githubusercontent.com/156560/120019870-320b2680-bfa6-11eb-86b9-1455223ef3ff.png)

