### PR TITLE
fix smda test xfail

### DIFF
--- a/tests/test_smda_features.py
+++ b/tests/test_smda_features.py
@@ -23,10 +23,10 @@ def test_smda_features(sample, scope, feature, expected):
     if scope.__name__ == "file" and isinstance(feature, capa.features.file.FunctionName) and expected is True:
         pytest.xfail("SMDA has no function ID")
 
-    if sample == "a1982..." and sys.platform == "win32":
+    if "a198216798ca38f280dc413f8c57f2c2" in sample and sys.platform == "win32":
         pytest.xfail("SMDA bug tracked #585")
 
-    if sample == "al-khaser x64" and sys.platform == "win32":
+    if "al-khaser_x64" in sample and sys.platform == "win32":
         pytest.xfail("SMDA bug tracked #585")
 
     do_test_feature_presence(get_smda_extractor, sample, scope, feature, expected)


### PR DESCRIPTION
fixes xfails since ed02088c820b95119c776ca43c51e79f22c81cac introduces new method to parametrize tests

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [x] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
