### PR TITLE
ci: lint CHANGELOG

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,16 @@ on:
     branches: [ master ]
 
 jobs:
+  changelog_format:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout capa
+      uses: actions/checkout@v2
+    # The sync GH action in capa-rules relies on a single '- *$' in the CHANGELOG file
+    - name: Ensure CHANGELOG has '- *$'
+      run: |
+        number=$(grep '\- *$' CHANGELOG.md | wc -l)
+        if [ $number != 1 ]; then exit 1; fi
   code_style:
     runs-on: ubuntu-20.04
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,7 @@ It includes many new rules, including all new techniques introduced in MITRE ATT
 ### Development
 
 - ci: add capa release link to capa-rules tag #517 @Ana06
-- ci, changelog: update `New Rules` section in CHANGELOG automatically https://github.com/fireeye/capa-rules/pull/374 #549 @Ana06
+- ci, changelog: update `New Rules` section in CHANGELOG automatically https://github.com/fireeye/capa-rules/pull/374 #549 #604 @Ana06
 - ci, changelog: support multiple author in sync GH https://github.com/fireeye/capa-rules/pull/378 @Ana06
 - ci, lint: check statements for single child statements #563 @mr-tz
 - ci: reject PRs without CHANGELOG update to ensure CHANGELOG is kept up-to-date. #584 @Ana06


### PR DESCRIPTION
The sync GH action in capa-rules relies on a single `- *$` in the CHANGELOG file. Check in the tests that this is the case to avoid that it is removed.

This happened in https://github.com/fireeye/capa/pull/591, which caused that the new rules in https://github.com/fireeye/capa-rules/pull/400 were not added to the CHANGELOG.

There are probably better alternatives to update the CHANGELOG than looking for `- *$`. Any ideas of how to do this in a robuster way that doesn't need linting?  🤔 Otherwise this is an easy solution which may be good enough.



<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/fireeye/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
