### PR TITLE
Use Ana06/get-changed-files@v1.2

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - name: Get changed files
       id: files
-      uses: Ana06/get-changed-files@v1.1
+      uses: Ana06/get-changed-files@v1.2
     - name: check changelog updated
       id: changelog_updated
       env:


### PR DESCRIPTION
Use [Ana06/get-changed-files@v1.2](https://github.com/Ana06/get-changed-files/releases/tag/v1.2) which removes the _head commit is ahead of the base commit_ check. This made the action failed in not up-to-date branches (in which rebasing is needed).

I think we should update capa-rules and capa-testfiles as well.

It supersedes https://github.com/fireeye/capa/pull/599


<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/fireeye/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [X] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [X] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [X] No documentation update needed
