### PR TITLE
correctly render negative numbers and offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ It includes many new rules, including all new techniques introduced in MITRE ATT
 - json: breaking change in results document; now contains parsed ATT&CK and MBC fields instead of canonical representation #526 @mr-tz
 - json: breaking change: record all matching strings for regex #159 @williballenthin
 - main: implement file limitations via rules not code #390 @williballenthin
+- json: breaking change: correctly render negative offsets #619 @williballenthin
 
 ### Development
 

--- a/capa/features/insn.py
+++ b/capa/features/insn.py
@@ -6,6 +6,7 @@
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+import capa.render.utils
 from capa.features import Feature
 
 
@@ -24,7 +25,7 @@ class Number(Feature):
         super(Number, self).__init__(value, arch=arch, description=description)
 
     def get_value_str(self):
-        return "0x%X" % self.value
+        return capa.render.utils.hex(self.value)
 
 
 class Offset(Feature):
@@ -32,7 +33,7 @@ class Offset(Feature):
         super(Offset, self).__init__(value, arch=arch, description=description)
 
     def get_value_str(self):
-        return "0x%X" % self.value
+        return capa.render.utils.hex(self.value)
 
 
 class Mnemonic(Feature):


### PR DESCRIPTION
closes #619 by correctly rendering negative numbers and offsets.

this is a breaking change because our JSON document currently contains incorrectly formatted values. probably noone relies on this, though.

### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
