### PR TITLE
disable viv creation by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,7 +130,7 @@ It includes many new rules, including all new techniques introduced in MITRE ATT
 - main: implement file limitations via rules not code #390 @williballenthin
 - json: breaking change: correctly render negative offsets #619 @williballenthin
 - library: breaking change: remove logic from `__init__.py` throughout #622 @williballenthin
-- main: don't create .viv files unless CAPA_SAVE_WORKSPACE is set #507 @williballenthin
+- main: don't create .viv files unless CAPA_SAVE_WORKSPACE environment variable is set #507 @williballenthin
 - library: add type annotations for use with mypy #447 @williballenthin
 
 ### Development

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ It includes many new rules, including all new techniques introduced in MITRE ATT
 - main: implement file limitations via rules not code #390 @williballenthin
 - json: breaking change: correctly render negative offsets #619 @williballenthin
 - library: breaking change: remove logic from `__init__.py` throughout #622 @williballenthin
+- main: don't create .viv files unless CAPA_SAVE_WORKSPACE is set #507 @williballenthin
 
 ### Development
 

--- a/capa/features/freeze.py
+++ b/capa/features/freeze.py
@@ -254,7 +254,7 @@ def main(argv=None):
     args = parser.parse_args(args=argv)
     capa.main.handle_common_args(args)
 
-    extractor = capa.main.get_extractor(args.sample, args.format, args.backend, sigpaths=args.signatures)
+    extractor = capa.main.get_extractor(args.sample, args.format, args.backend, args.signatures, False)
     with open(args.output, "wb") as f:
         f.write(dump(extractor))
 

--- a/capa/main.py
+++ b/capa/main.py
@@ -846,7 +846,9 @@ def main(argv=None):
         should_save_workspace = os.environ.get("CAPA_SAVE_WORKSPACE") not in ("0", "no", "NO", "n", None)
 
         try:
-            extractor = get_extractor(args.sample, format, args.backend, args.signatures, should_save_workspace, disable_progress=args.quiet)
+            extractor = get_extractor(
+                args.sample, format, args.backend, args.signatures, should_save_workspace, disable_progress=args.quiet
+            )
         except UnsupportedFormatError:
             logger.error("-" * 80)
             logger.error(" Input file does not appear to be a PE file.")

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -11,3 +11,9 @@ For example, `capa -t william.ballenthin@mandiant.com` runs rules that reference
 
 ### IDA Pro plugin: capa explorer
 Please check out the [capa explorer documentation](/capa/ida/plugin/README.md).
+
+### save time by reusing .viv files
+Set the environment variable `CAPA_SAVE_WORKSPACE` to instruct the underlying analysis engine to 
+cache its intermediate results to the file system. For example, vivisect will create `.viv` files.
+Subsequently, capa may run faster when reprocessing the same input file.
+This is particularly useful during rule development as you repeatedly test a rule against a known sample.

--- a/scripts/bulk-process.py
+++ b/scripts/bulk-process.py
@@ -95,9 +95,10 @@ def get_capa_results(args):
       capabilities (dict): the matched capabilities and their result objects
     """
     rules, format, path = args
+    should_save_workspace = os.environ.get("CAPA_SAVE_WORKSPACE") not in ("0", "no", "NO", "n", None)
     logger.info("computing capa results for: %s", path)
     try:
-        extractor = capa.main.get_extractor(path, format, capa.main.BACKEND_VIV, args.signatures, disable_progress=True)
+        extractor = capa.main.get_extractor(path, format, capa.main.BACKEND_VIV, args.signatures, should_save_workspace, disable_progress=True)
     except capa.main.UnsupportedFormatError:
         # i'm 100% sure if multiprocessing will reliably raise exceptions across process boundaries.
         # so instead, return an object with explicit success/failure status.

--- a/scripts/bulk-process.py
+++ b/scripts/bulk-process.py
@@ -98,7 +98,9 @@ def get_capa_results(args):
     should_save_workspace = os.environ.get("CAPA_SAVE_WORKSPACE") not in ("0", "no", "NO", "n", None)
     logger.info("computing capa results for: %s", path)
     try:
-        extractor = capa.main.get_extractor(path, format, capa.main.BACKEND_VIV, args.signatures, should_save_workspace, disable_progress=True)
+        extractor = capa.main.get_extractor(
+            path, format, capa.main.BACKEND_VIV, args.signatures, should_save_workspace, disable_progress=True
+        )
     except capa.main.UnsupportedFormatError:
         # i'm 100% sure if multiprocessing will reliably raise exceptions across process boundaries.
         # so instead, return an object with explicit success/failure status.

--- a/scripts/capa_as_library.py
+++ b/scripts/capa_as_library.py
@@ -193,7 +193,7 @@ def render_dictionary(doc):
 def capa_details(file_path, output_format="dictionary"):
 
     # extract features and find capabilities
-    extractor = capa.main.get_extractor(file_path, "auto", capa.main.BACKEND_VIV, sigpaths=[], disable_progress=True)
+    extractor = capa.main.get_extractor(file_path, "auto", capa.main.BACKEND_VIV, [], False, disable_progress=True)
     capabilities, counts = capa.main.find_capabilities(rules, extractor, disable_progress=True)
 
     # collect metadata (used only to make rendering more complete)

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -220,7 +220,7 @@ class DoesntMatchExample(Lint):
 
             try:
                 extractor = capa.main.get_extractor(
-                    path, "auto", capa.main.BACKEND_VIV, sigpaths=DEFAULT_SIGNATURES, disable_progress=True
+                    path, "auto", capa.main.BACKEND_VIV, DEFAULT_SIGNATURES, False, disable_progress=True
                 )
                 capabilities, meta = capa.main.find_capabilities(ctx["rules"], extractor, disable_progress=True)
             except Exception as e:

--- a/scripts/show-capabilities-by-function.py
+++ b/scripts/show-capabilities-by-function.py
@@ -155,7 +155,9 @@ def main(argv=None):
         should_save_workspace = os.environ.get("CAPA_SAVE_WORKSPACE") not in ("0", "no", "NO", "n", None)
 
         try:
-            extractor = capa.main.get_extractor(args.sample, args.format, args.backend, args.signatures, should_save_workspace)
+            extractor = capa.main.get_extractor(
+                args.sample, args.format, args.backend, args.signatures, should_save_workspace
+            )
         except capa.main.UnsupportedFormatError:
             logger.error("-" * 80)
             logger.error(" Input file does not appear to be a PE file.")

--- a/scripts/show-capabilities-by-function.py
+++ b/scripts/show-capabilities-by-function.py
@@ -152,9 +152,10 @@ def main(argv=None):
             extractor = capa.features.freeze.load(f.read())
     else:
         format = args.format
+        should_save_workspace = os.environ.get("CAPA_SAVE_WORKSPACE") not in ("0", "no", "NO", "n", None)
 
         try:
-            extractor = capa.main.get_extractor(args.sample, args.format, args.backend, args.signatures)
+            extractor = capa.main.get_extractor(args.sample, args.format, args.backend, args.signatures, should_save_workspace)
         except capa.main.UnsupportedFormatError:
             logger.error("-" * 80)
             logger.error(" Input file does not appear to be a PE file.")

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -84,6 +84,7 @@ def get_viv_extractor(path):
         vw = capa.main.get_workspace(path, "sc64", sigpaths=sigpaths)
     else:
         vw = capa.main.get_workspace(path, "auto", sigpaths=sigpaths)
+    vw.saveWorkspace()
     extractor = capa.features.extractors.viv.extractor.VivisectFeatureExtractor(vw, path)
     fixup_viv(path, extractor)
     return extractor


### PR DESCRIPTION
by default, don't create .viv files, unless env var `CAPA_SAVE_WORKSPACE` is set.

![image](https://user-images.githubusercontent.com/156560/122104338-cd88fd80-cdd4-11eb-8fb9-caae45f8cb07.png)

closes #507 


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [x] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [ ] No documentation update needed
