### PR TITLE
add option to select specificed byte count for bytes feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+- explorer: allow user to add specified number of bytes when adding a Bytes feature in the Rule Generator #689 @mike-hunhoff
+
 ### Breaking Changes
 
 ### New Rules (4)

--- a/capa/ida/plugin/view.py
+++ b/capa/ida/plugin/view.py
@@ -9,6 +9,7 @@ import re
 from collections import Counter
 
 import idc
+import idaapi
 from PyQt5 import QtGui, QtCore, QtWidgets
 
 import capa.rules
@@ -779,6 +780,14 @@ class CapaExplorerRulegenFeatures(QtWidgets.QTreeWidget):
         if selected:
             self.editor.update_features(selected)
 
+    def slot_add_n_bytes_feature(self, action):
+        """ """
+        count = idaapi.ask_long(16, f"Enter number of bytes (1-{capa.features.common.MAX_BYTES_FEATURE_SIZE}):")
+        if count and 1 <= count <= capa.features.common.MAX_BYTES_FEATURE_SIZE:
+            item = self.selectedItems()[0].data(0, 0x100)
+            item.value = item.value[:count]
+            self.editor.update_features([item])
+
     def slot_custom_context_menu_requested(self, pos):
         """ """
         actions = []
@@ -790,6 +799,8 @@ class CapaExplorerRulegenFeatures(QtWidgets.QTreeWidget):
 
         if selected_items_count == 1:
             action_add_features_fmt = "Add feature"
+            if isinstance(self.selectedItems()[0].data(0, 0x100), capa.features.common.Bytes):
+                actions.append(("Add n bytes...", (), self.slot_add_n_bytes_feature))
         else:
             action_add_features_fmt = "Add %d features" % selected_items_count
 


### PR DESCRIPTION
closes #544.

allow user to add specified number of bytes when adding a `Bytes` feature in the rule generator. adds `Add n bytes...` option to context menu for `Bytes` features.