### PR TITLE
add option to limit features to currently selected disassembly address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - explorer: allow user to add specified number of bytes when adding a Bytes feature in the Rule Generator #689 @mike-hunhoff
 - explorer: enforce max column width Features and Editor panes #691 @mike-hunhoff
+- explorer: add option to limit features to currently selected disassembly address #692 @mike-hunhoff
 
 ### Breaking Changes
 

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -567,7 +567,7 @@ class CapaExplorerForm(idaapi.PluginForm):
 
     def update_rulegen_tree_limit_features_to_selection(self, ea):
         """ """
-        self.view_rulegen_features.filter_items_by_ea(ea, None)
+        self.view_rulegen_features.filter_items_by_ea(ea)
 
     def ida_hook_screen_ea_changed(self, widget, new_ea, old_ea):
         """function hook for IDA "screen ea changed" action
@@ -1188,7 +1188,7 @@ class CapaExplorerForm(idaapi.PluginForm):
     def slot_checkbox_limit_features_by_ea(self, state):
         """ """
         if state == QtCore.Qt.Checked:
-            self.view_rulegen_features.filter_items_by_ea(idaapi.get_screen_ea(), None)
+            self.view_rulegen_features.filter_items_by_ea(idaapi.get_screen_ea())
         else:
             self.view_rulegen_features.show_all_items()
 

--- a/capa/ida/plugin/form.py
+++ b/capa/ida/plugin/form.py
@@ -275,6 +275,7 @@ class CapaExplorerForm(idaapi.PluginForm):
         self.view_rulegen_editor = None
         self.view_rulegen_header_label = None
         self.view_rulegen_search = None
+        self.view_rulegen_limit_features_by_ea = None
         self.rulegen_current_function = None
         self.rulegen_bb_features_cache = {}
         self.rulegen_func_features_cache = {}
@@ -465,6 +466,10 @@ class CapaExplorerForm(idaapi.PluginForm):
         label2.setText("Editor")
         label2.setFont(font)
 
+        self.view_rulegen_limit_features_by_ea = QtWidgets.QCheckBox("Limit features to current dissasembly address")
+        self.view_rulegen_limit_features_by_ea.setChecked(False)
+        self.view_rulegen_limit_features_by_ea.stateChanged.connect(self.slot_checkbox_limit_features_by_ea)
+
         self.view_rulegen_status_label = QtWidgets.QLabel()
         self.view_rulegen_status_label.setAlignment(QtCore.Qt.AlignLeft)
         self.view_rulegen_status_label.setText("")
@@ -495,6 +500,7 @@ class CapaExplorerForm(idaapi.PluginForm):
         layout3.addWidget(self.view_rulegen_editor, 65)
 
         layout2.addWidget(self.view_rulegen_header_label)
+        layout2.addWidget(self.view_rulegen_limit_features_by_ea)
         layout2.addWidget(self.view_rulegen_search)
         layout2.addWidget(self.view_rulegen_features)
 
@@ -559,6 +565,10 @@ class CapaExplorerForm(idaapi.PluginForm):
         self.limit_results_to_function(idaapi.get_func(ea))
         self.view_tree.reset_ui()
 
+    def update_rulegen_tree_limit_features_to_selection(self, ea):
+        """ """
+        self.view_rulegen_features.filter_items_by_ea(ea, None)
+
     def ida_hook_screen_ea_changed(self, widget, new_ea, old_ea):
         """function hook for IDA "screen ea changed" action
 
@@ -578,6 +588,9 @@ class CapaExplorerForm(idaapi.PluginForm):
 
         if not idaapi.get_func(new_ea):
             return
+
+        if self.view_tabs.currentIndex() == 1 and self.view_rulegen_limit_features_by_ea.isChecked():
+            return self.update_rulegen_tree_limit_features_to_selection(new_ea)
 
         if idaapi.get_func(new_ea) == idaapi.get_func(old_ea):
             # user navigated same function - ignore
@@ -980,6 +993,7 @@ class CapaExplorerForm(idaapi.PluginForm):
         self.view_rulegen_editor.reset_view()
         self.view_rulegen_preview.reset_view()
         self.view_rulegen_search.clear()
+        self.view_rulegen_limit_features_by_ea.setChecked(False)
         self.set_rulegen_preview_border_neutral()
         self.rulegen_current_function = None
         self.rulegen_func_features_cache = {}
@@ -1170,6 +1184,13 @@ class CapaExplorerForm(idaapi.PluginForm):
             self.range_model_proxy.reset_address_range_filter()
 
         self.view_tree.reset_ui()
+
+    def slot_checkbox_limit_features_by_ea(self, state):
+        """ """
+        if state == QtCore.Qt.Checked:
+            self.view_rulegen_features.filter_items_by_ea(idaapi.get_screen_ea(), None)
+        else:
+            self.view_rulegen_features.show_all_items()
 
     def slot_checkbox_show_results_by_function_changed(self, state):
         """slot activated if checkbox clicked

--- a/capa/ida/plugin/view.py
+++ b/capa/ida/plugin/view.py
@@ -863,6 +863,44 @@ class CapaExplorerRulegenFeatures(QtWidgets.QTreeWidget):
         else:
             self.show_all_items()
 
+    def filter_items_by_ea(self, min_ea, max_ea=None):
+        """ """
+        visited = []
+
+        def show_item_and_parents(_o):
+            """iteratively show and expand an item and its' parents"""
+            while _o:
+                visited.append(_o)
+                _o.setHidden(False)
+                _o.setExpanded(True)
+                _o = _o.parent()
+
+        for o in iterate_tree(self):
+            if o in visited:
+                # save some cycles, only visit item once
+                continue
+
+            # read ea from "Address" column
+            o_ea = o.text(CapaExplorerRulegenFeatures.get_column_address_index())
+
+            if o_ea == "":
+                # ea may be empty, hide by default
+                o.setHidden(True)
+                continue
+
+            o_ea = int(o_ea, 16)
+
+            if max_ea is not None and min_ea <= o_ea <= max_ea:
+                show_item_and_parents(o)
+            elif o_ea == min_ea:
+                show_item_and_parents(o)
+            else:
+                # made it here, hide by default
+                o.setHidden(True)
+
+        # resize the view for UX
+        resize_columns_to_content(self.header())
+
     def style_parent_node(self, o):
         """ """
         font = QtGui.QFont()


### PR DESCRIPTION
closes #473.

This update adds an option to limit features displayed in the `Features` pane to the currently selected address in the disassembly view. Opting for simplest implementation here to balance ROI.