### PR TITLE
linter enhancements

### DIFF
--- a/.github/mypy/mypy.ini
+++ b/.github/mypy/mypy.ini
@@ -68,3 +68,6 @@ ignore_missing_imports = True
 
 [mypy-pytest.*]
 ignore_missing_imports = True
+
+[mypy-devtools.*]
+ignore_missing_imports = True

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - main: fix `KeyError: 0` when reporting results @williballehtin #703
 - main: fix potential false negatives due to namespaces across scopes @williballenthin #721
 - linter: suppress some warnings about imports from ntdll/ntoskrnl @williballenthin #743
+- linter: suppress some warnings about missing examples in the nursery @williballenthin #747
 
 ### capa explorer IDA Pro plugin
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -13,6 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
 """
+import gc
 import os
 import sys
 import time
@@ -237,6 +238,13 @@ def get_sample_capabilities(ctx: Context, path: Path) -> Set[str]:
     capabilities = set(capabilities.keys())
     logger.debug("computed results: %s: %d capabilities", nice_path, len(capabilities))
     ctx.capabilities_by_sample[path] = capabilities
+
+    # when i (wb) run the linter in thorough mode locally,
+    # the OS occasionally kills the process due to memory usage.
+    # so, be extra aggressive in keeping memory usage down.
+    #
+    # tbh, im not sure this actually does anything, but maybe it helps?
+    gc.collect()
 
     return capabilities
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -27,6 +27,7 @@ import posixpath
 
 import termcolor
 import ruamel.yaml
+import tqdm.contrib.logging
 
 import capa.main
 import capa.rules
@@ -699,11 +700,13 @@ def lint(ctx, rules):
     """
     ret = {}
 
-    for name, rule in rules.rules.items():
-        if rule.meta.get("capa/subscope-rule", False):
-            continue
+    with tqdm.contrib.logging.tqdm_logging_redirect(rules.rules.items(), unit="rule") as pbar:
+        for name, rule in pbar:
+            if rule.meta.get("capa/subscope-rule", False):
+                continue
 
-        ret[name] = lint_rule(ctx, rule)
+            pbar.set_description("linting rule: %s" % (name))
+            ret[name] = lint_rule(ctx, rule)
 
     return ret
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -19,12 +19,15 @@ import time
 import string
 import difflib
 import hashlib
+import inspect
 import logging
 import os.path
 import argparse
 import itertools
 import posixpath
+import contextlib
 
+import tqdm
 import termcolor
 import ruamel.yaml
 import tqdm.contrib.logging
@@ -686,6 +689,41 @@ def lint_rule(ctx, rule):
     return (lints_failed, lints_warned)
 
 
+def width(s, count):
+    if len(s) > count:
+        return s[: count - 3] + "..."
+    else:
+        return s.ljust(count)
+
+
+@contextlib.contextmanager
+def redirecting_print_to_tqdm():
+    """
+    tqdm (progress bar) expects to have fairly tight control over console output.
+    so calls to `print()` will break the progress bar and make things look bad.
+    so, this context manager temporarily replaces the `print` implementation
+    with one that is compatible with tqdm.
+
+    via: https://stackoverflow.com/a/42424890/87207
+    """
+    old_print = print
+
+    def new_print(*args, **kwargs):
+
+        # If tqdm.tqdm.write raises error, use builtin print
+        try:
+            tqdm.tqdm.write(*args, **kwargs)
+        except:
+            old_print(*args, **kwargs)
+
+    try:
+        # Globaly replace print with new_print
+        inspect.builtins.print = new_print
+        yield
+    finally:
+        inspect.builtins.print = old_print
+
+
 def lint(ctx, rules):
     """
     Args:
@@ -701,12 +739,13 @@ def lint(ctx, rules):
     ret = {}
 
     with tqdm.contrib.logging.tqdm_logging_redirect(rules.rules.items(), unit="rule") as pbar:
-        for name, rule in pbar:
-            if rule.meta.get("capa/subscope-rule", False):
-                continue
+        with redirecting_print_to_tqdm():
+            for name, rule in pbar:
+                if rule.meta.get("capa/subscope-rule", False):
+                    continue
 
-            pbar.set_description("linting rule: %s" % (name))
-            ret[name] = lint_rule(ctx, rule)
+                pbar.set_description(width("linting rule: %s" % (name), 48))
+                ret[name] = lint_rule(ctx, rule)
 
     return ret
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -631,30 +631,34 @@ def lint_rule(ctx, rule):
     )
 
     if len(violations) > 0:
-        category = rule.meta.get("rule-category")
+        # don't show nursery rules with a single violation: needs examples.
+        # this is by far the most common reason to be in the nursery,
+        # and ends up just producing a lot of noise.
+        if not (is_nursery_rule(rule) and len(violations) == 1 and violations[0].name == "missing examples"):
+            category = rule.meta.get("rule-category")
 
-        print("")
-        print(
-            "%s%s %s"
-            % (
-                "    (nursery) " if is_nursery_rule(rule) else "",
-                rule.name,
-                ("(%s)" % category) if category else "",
-            )
-        )
-
-        for violation in violations:
+            print("")
             print(
-                "%s  %s: %s: %s"
+                "%s%s %s"
                 % (
-                    "    " if is_nursery_rule(rule) else "",
-                    Lint.WARN if is_nursery_rule(rule) else violation.level,
-                    violation.name,
-                    violation.recommendation,
+                    "    (nursery) " if is_nursery_rule(rule) else "",
+                    rule.name,
+                    ("(%s)" % category) if category else "",
                 )
             )
 
-        print("")
+            for violation in violations:
+                print(
+                    "%s  %s: %s: %s"
+                    % (
+                        "    " if is_nursery_rule(rule) else "",
+                        Lint.WARN if is_nursery_rule(rule) else violation.level,
+                        violation.name,
+                        violation.recommendation,
+                    )
+                )
+
+            print("")
 
     if is_nursery_rule(rule):
         has_examples = not any(map(lambda v: v.level == Lint.FAIL and v.name == "missing examples", violations))

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -234,8 +234,13 @@ def get_sample_capabilities(ctx: Context, path: Path) -> Set[str]:
     extractor = capa.main.get_extractor(
         nice_path, "auto", capa.main.BACKEND_VIV, DEFAULT_SIGNATURES, False, disable_progress=True
     )
+
     capabilities, _ = capa.main.find_capabilities(ctx.rules, extractor, disable_progress=True)
-    capabilities = set(capabilities.keys())
+    # mypy doesn't seem to be happy with the MatchResults type alias & set(...keys())?
+    # so we ignore a few types here.
+    capabilities = set(capabilities.keys())  # type: ignore
+    assert isinstance(capabilities, set)
+
     logger.debug("computed results: %s: %d capabilities", nice_path, len(capabilities))
     ctx.capabilities_by_sample[path] = capabilities
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -226,16 +226,16 @@ DEFAULT_SIGNATURES = capa.main.get_default_signatures()
 def get_sample_capabilities(ctx: Context, path: Path) -> Set[str]:
     nice_path = os.path.abspath(str(path))
     if path in ctx.capabilities_by_sample:
-        logger.info("found cached results: %s: %d capabilities", nice_path, len(ctx.capabilities_by_sample[path]))
+        logger.debug("found cached results: %s: %d capabilities", nice_path, len(ctx.capabilities_by_sample[path]))
         return ctx.capabilities_by_sample[path]
 
-    logger.info("analyzing sample: %s", nice_path)
+    logger.debug("analyzing sample: %s", nice_path)
     extractor = capa.main.get_extractor(
         nice_path, "auto", capa.main.BACKEND_VIV, DEFAULT_SIGNATURES, False, disable_progress=True
     )
     capabilities, _ = capa.main.find_capabilities(ctx.rules, extractor, disable_progress=True)
     capabilities = set(capabilities.keys())
-    logger.info("computed results: %s: %d capabilities", nice_path, len(capabilities))
+    logger.debug("computed results: %s: %d capabilities", nice_path, len(capabilities))
     ctx.capabilities_by_sample[path] = capabilities
 
     return capabilities


### PR DESCRIPTION
a number of semi-related enhancements to the linter:

  - add typing
  - add progress bar
  - add (in-memory) cache of analysis results per-path 
  - don't display "find examples" if its the only violation for a nursery rule

all together, this should make the output much more readable while also being more performant (via the cache).
